### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ ENARMAX es una pequeña aplicación web para repasar tarjetas médicas. Las tarj
 1. Clona este repositorio.
 2. Abre el archivo `index.html` en tu navegador.
 3. Interactúa con las tarjetas usando los botones disponibles.
+4. Cambia entre modo día y noche con el botón "Modo Noche".
 
 No se requieren dependencias externas ni servidores adicionales; todo funciona de manera estática en el navegador.
 

--- a/app.js
+++ b/app.js
@@ -40,6 +40,7 @@ const difficultyBtns = document.querySelectorAll('.difficulty-btn');
 const addCardBtn = document.getElementById('add-card-btn');
 const newQuestionInput = document.getElementById('new-question');
 const newAnswerInput = document.getElementById('new-answer');
+const themeToggle = document.getElementById('theme-toggle');
 
 // App state
 let currentCardIndex = 0;
@@ -48,9 +49,24 @@ let pendingCards = 0;
 let newCards = 0;
 let isFlipped = false;
 
+function loadTheme() {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
+        document.body.classList.add('dark-mode');
+        if (themeToggle) themeToggle.textContent = 'Modo Día';
+    }
+}
+
+function toggleTheme() {
+    const isDark = document.body.classList.toggle('dark-mode');
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    themeToggle.textContent = isDark ? 'Modo Día' : 'Modo Noche';
+}
+
 // Initialize the app
 function init() {
     loadFlashcards();
+    loadTheme();
     updateStats();
     showCard();
     
@@ -59,6 +75,7 @@ function init() {
     nextBtn.addEventListener('click', showNextCard);
     flipBtn.addEventListener('click', flipCard);
     addCardBtn.addEventListener('click', addNewCard);
+    if (themeToggle) themeToggle.addEventListener('click', toggleTheme);
     
     // Difficulty buttons
     difficultyBtns.forEach(btn => {

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <div class="container">
         <header>
             <h1>Repaso de Tarjetas Médicas</h1>
+            <button id="theme-toggle" class="theme-toggle">Modo Noche</button>
             <div class="stats">
                 <div class="stat-card">
                     <span class="stat-number" id="today-count">0</span>

--- a/styles.css
+++ b/styles.css
@@ -6,8 +6,20 @@
     --warning-color: #ffc107;
     --light-color: #f8f9fa;
     --dark-color: #343a40;
+    --background-color: #f0f2f5;
+    --text-color: #333;
+    --card-background: white;
+    --card-background-alt: #f8f9fa;
     --border-radius: 8px;
     --box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+body.dark-mode {
+    --background-color: #121212;
+    --text-color: #e0e0e0;
+    --card-background: #1e1e1e;
+    --card-background-alt: #2c2c2c;
+    --box-shadow: 0 4px 6px rgba(0, 0, 0, 0.4);
 }
 
 * {
@@ -19,8 +31,8 @@
 body {
     font-family: 'Roboto', sans-serif;
     line-height: 1.6;
-    background-color: #f0f2f5;
-    color: #333;
+    background-color: var(--background-color);
+    color: var(--text-color);
     padding: 20px;
 }
 
@@ -40,6 +52,17 @@ h1 {
     margin-bottom: 20px;
 }
 
+.theme-toggle {
+    background-color: var(--secondary-color);
+    color: white;
+    border: none;
+    padding: 8px 16px;
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    font-size: 0.9rem;
+    margin-bottom: 15px;
+}
+
 .stats {
     display: flex;
     justify-content: center;
@@ -48,7 +71,7 @@ h1 {
 }
 
 .stat-card {
-    background: white;
+    background: var(--card-background);
     padding: 15px 30px;
     border-radius: var(--border-radius);
     box-shadow: var(--box-shadow);
@@ -108,12 +131,12 @@ h1 {
     padding: 30px;
     border-radius: var(--border-radius);
     box-shadow: var(--box-shadow);
-    background: white;
+    background: var(--card-background);
 }
 
 .flashcard-back {
     transform: rotateY(180deg);
-    background: #f8f9fa;
+    background: var(--card-background-alt);
 }
 
 .controls {
@@ -179,7 +202,7 @@ h1 {
 }
 
 .add-card-form {
-    background: white;
+    background: var(--card-background);
     padding: 20px;
     border-radius: var(--border-radius);
     box-shadow: var(--box-shadow);


### PR DESCRIPTION
## Summary
- add button to toggle theme
- style dark mode using CSS variables
- implement theme persistence in app.js
- update README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c1e763018832890712a6d414ad259