### PR TITLE
Add specialty navigation with flashcards filter

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,8 @@
 let flashcards = [
     {
         question: "¿Qué es la hipertensión arterial?",
-        answer: "Es una condición médica en la que la presión arterial en las arterias es persistentemente elevada, generalmente definida como una presión sistólica de 140 mmHg o más y/o una presión diastólica de 90 mmHg o más.",
+        answer: "Es una condición médica en la que la presión arterial es persistentemente elevada, generalmente definida como una presión sistólica de 140 mmHg o más y/o una presión diastólica de 90 mmHg o más.",
+        specialty: "medicina-interna",
         difficulty: "medium",
         lastReviewed: null,
         nextReview: null,
@@ -11,6 +12,7 @@ let flashcards = [
     {
         question: "¿Cuáles son los signos vitales principales?",
         answer: "1. Temperatura corporal\n2. Frecuencia cardíaca (pulso)\n3. Presión arterial\n4. Frecuencia respiratoria\n5. Saturación de oxígeno",
+        specialty: "medicina-interna",
         difficulty: "easy",
         lastReviewed: null,
         nextReview: null,
@@ -19,7 +21,53 @@ let flashcards = [
     {
         question: "¿Qué es el síndrome de Cushing?",
         answer: "Es un trastorno hormonal causado por la exposición prolongada a niveles altos de cortisol. Los síntomas incluyen obesidad central, cara de luna llena, joroba de búfalo, estrías violáceas, hipertensión y diabetes mellitus.",
+        specialty: "medicina-interna",
         difficulty: "hard",
+        lastReviewed: null,
+        nextReview: null,
+        reviewCount: 0
+    },
+    {
+        question: "¿Cuál es la causa más frecuente de bronquiolitis?",
+        answer: "Virus sincitial respiratorio",
+        specialty: "pediatria",
+        difficulty: "medium",
+        lastReviewed: null,
+        nextReview: null,
+        reviewCount: 0
+    },
+    {
+        question: "¿Edad gestacional para tamizaje de diabetes gestacional?",
+        answer: "Entre las semanas 24 y 28 de gestación.",
+        specialty: "gineco-obstetricia",
+        difficulty: "medium",
+        lastReviewed: null,
+        nextReview: null,
+        reviewCount: 0
+    },
+    {
+        question: "¿Cuál es la tríada de la colecistitis aguda?",
+        answer: "Dolor en cuadrante superior derecho, fiebre y leucocitosis.",
+        specialty: "cirugia",
+        difficulty: "medium",
+        lastReviewed: null,
+        nextReview: null,
+        reviewCount: 0
+    },
+    {
+        question: "¿Cuál es la secuencia primaria de la evaluación en ATLS?",
+        answer: "A - Vía aérea con control cervical, B - Respiración, C - Circulación, D - Déficit neurológico, E - Exposición.",
+        specialty: "atls",
+        difficulty: "easy",
+        lastReviewed: null,
+        nextReview: null,
+        reviewCount: 0
+    },
+    {
+        question: "¿Dosis de adrenalina en paro cardiaco durante RCP?",
+        answer: "1 mg IV cada 3-5 minutos.",
+        specialty: "acls",
+        difficulty: "easy",
         lastReviewed: null,
         nextReview: null,
         reviewCount: 0
@@ -41,7 +89,9 @@ const addCardBtn = document.getElementById('add-card-btn');
 const newQuestionInput = document.getElementById('new-question');
 const newAnswerInput = document.getElementById('new-answer');
 const themeToggle = document.getElementById('theme-toggle');
+const specialtyTitle = document.getElementById("specialty-title");
 
+const specialtyNames = {"medicina-interna":"Medicina Interna","pediatria":"Pediatría","gineco-obstetricia":"Ginecología y Obstetricia","cirugia":"Cirugía","atls":"ATLS","acls":"ACLS"};
 // App state
 let currentCardIndex = 0;
 let cardsReviewedToday = 0;
@@ -57,6 +107,11 @@ function loadTheme() {
     }
 }
 
+function getQueryParam(name) {
+    const params = new URLSearchParams(window.location.search);
+    return params.get(name);
+}
+
 function toggleTheme() {
     const isDark = document.body.classList.toggle('dark-mode');
     localStorage.setItem('theme', isDark ? 'dark' : 'light');
@@ -66,15 +121,19 @@ function toggleTheme() {
 // Initialize the app
 function init() {
     loadFlashcards();
+    const specialty = getQueryParam("specialty");
+    if (specialty) {
+        flashcards = flashcards.filter(c => c.specialty === specialty);
+        if (specialtyTitle) specialtyTitle.textContent = specialtyNames[specialty] || "";
+    }
     loadTheme();
+    updatePendingAndNewCounts();
     updateStats();
     showCard();
-    
-    // Event listeners
-    prevBtn.addEventListener('click', showPreviousCard);
     nextBtn.addEventListener('click', showNextCard);
     flipBtn.addEventListener('click', flipCard);
     addCardBtn.addEventListener('click', addNewCard);
+    prevBtn.addEventListener("click", showPreviousCard);
     if (themeToggle) themeToggle.addEventListener('click', toggleTheme);
     
     // Difficulty buttons

--- a/flashcards.html
+++ b/flashcards.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Repaso de Tarjetas Médicas</title>
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Repaso de Tarjetas Médicas</h1>
+            <h2 id="specialty-title"></h2>
+            <a href="index.html" class="back-link">&larr; Inicio</a>
+            <button id="theme-toggle" class="theme-toggle">Modo Noche</button>
+            <div class="stats">
+                <div class="stat-card">
+                    <span class="stat-number" id="today-count">0</span>
+                    <span class="stat-label">Hoy</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-number" id="pending-count">0</span>
+                    <span class="stat-label">Pendientes</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-number" id="new-count">0</span>
+                    <span class="stat-label">Nuevas</span>
+                </div>
+            </div>
+        </header>
+
+        <main>
+            <div class="flashcard-container">
+                <div class="flashcard" id="flashcard">
+                    <div class="flashcard-inner">
+                        <div class="flashcard-front">
+                            <p id="question">Cargando preguntas...</p>
+                        </div>
+                        <div class="flashcard-back">
+                            <p id="answer"></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="controls">
+                <button id="prev-btn" class="control-btn" disabled>← Anterior</button>
+                <button id="flip-btn" class="control-btn primary">Mostrar Respuesta</button>
+                <button id="next-btn" class="control-btn primary">Siguiente →</button>
+            </div>
+
+            <div class="difficulty-buttons">
+                <button class="difficulty-btn easy" data-difficulty="easy">Fácil</button>
+                <button class="difficulty-btn medium" data-difficulty="medium">Medio</button>
+                <button class="difficulty-btn hard" data-difficulty="hard">Difícil</button>
+            </div>
+        </main>
+
+        <div class="add-card-form">
+            <h3>Agregar Nueva Tarjeta</h3>
+            <div class="form-group">
+                <input type="text" id="new-question" placeholder="Pregunta" class="form-input">
+            </div>
+            <div class="form-group">
+                <textarea id="new-answer" placeholder="Respuesta" class="form-textarea"></textarea>
+            </div>
+            <button id="add-card-btn" class="primary">Agregar Tarjeta</button>
+        </div>
+    </div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,70 +3,41 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Repaso de Tarjetas Médicas</title>
+    <title>Especialidades Médicas</title>
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
-    <div class="container">
+    <div class="container home">
         <header>
-            <h1>Repaso de Tarjetas Médicas</h1>
-            <button id="theme-toggle" class="theme-toggle">Modo Noche</button>
-            <div class="stats">
-                <div class="stat-card">
-                    <span class="stat-number" id="today-count">0</span>
-                    <span class="stat-label">Hoy</span>
-                </div>
-                <div class="stat-card">
-                    <span class="stat-number" id="pending-count">0</span>
-                    <span class="stat-label">Pendientes</span>
-                </div>
-                <div class="stat-card">
-                    <span class="stat-number" id="new-count">0</span>
-                    <span class="stat-label">Nuevas</span>
-                </div>
-            </div>
+            <h1>Selecciona una Especialidad</h1>
         </header>
-
-        <main>
-            <div class="flashcard-container">
-                <div class="flashcard" id="flashcard">
-                    <div class="flashcard-inner">
-                        <div class="flashcard-front">
-                            <p id="question">Cargando preguntas...</p>
-                        </div>
-                        <div class="flashcard-back">
-                            <p id="answer"></p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="controls">
-                <button id="prev-btn" class="control-btn" disabled>← Anterior</button>
-                <button id="flip-btn" class="control-btn primary">Mostrar Respuesta</button>
-                <button id="next-btn" class="control-btn primary">Siguiente →</button>
-            </div>
-
-            <div class="difficulty-buttons">
-                <button class="difficulty-btn easy" data-difficulty="easy">Fácil</button>
-                <button class="difficulty-btn medium" data-difficulty="medium">Medio</button>
-                <button class="difficulty-btn hard" data-difficulty="hard">Difícil</button>
-            </div>
+        <main class="specialty-grid">
+            <a href="flashcards.html?specialty=medicina-interna" class="specialty-card">
+                <span class="emoji">🩺</span>
+                <span>Medicina Interna</span>
+            </a>
+            <a href="flashcards.html?specialty=pediatria" class="specialty-card">
+                <span class="emoji">👶</span>
+                <span>Pediatría</span>
+            </a>
+            <a href="flashcards.html?specialty=gineco-obstetricia" class="specialty-card">
+                <span class="emoji">🤰</span>
+                <span>Ginecología y Obstetricia</span>
+            </a>
+            <a href="flashcards.html?specialty=cirugia" class="specialty-card">
+                <span class="emoji">🔪</span>
+                <span>Cirugía</span>
+            </a>
+            <a href="flashcards.html?specialty=atls" class="specialty-card">
+                <span class="emoji">🚑</span>
+                <span>ATLS</span>
+            </a>
+            <a href="flashcards.html?specialty=acls" class="specialty-card">
+                <span class="emoji">❤️</span>
+                <span>ACLS</span>
+            </a>
         </main>
-
-        <div class="add-card-form">
-            <h3>Agregar Nueva Tarjeta</h3>
-            <div class="form-group">
-                <input type="text" id="new-question" placeholder="Pregunta" class="form-input">
-            </div>
-            <div class="form-group">
-                <textarea id="new-answer" placeholder="Respuesta" class="form-textarea"></textarea>
-            </div>
-            <button id="add-card-btn" class="primary">Agregar Tarjeta</button>
-        </div>
     </div>
-
-    <script src="app.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -269,3 +269,45 @@ h1 {
         height: 250px;
     }
 }
+
+/* Home page specialty grid */
+.home header {
+    text-align: center;
+    margin-bottom: 40px;
+}
+
+.specialty-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 20px;
+}
+
+.specialty-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    color: var(--text-color);
+    background: var(--card-background);
+    padding: 20px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    transition: transform 0.2s;
+}
+
+.specialty-card:hover {
+    transform: translateY(-4px);
+}
+
+.specialty-card .emoji {
+    font-size: 2.5rem;
+    margin-bottom: 10px;
+}
+
+.back-link {
+    display: inline-block;
+    margin-bottom: 10px;
+    text-decoration: none;
+    color: var(--primary-color);
+}


### PR DESCRIPTION
## Summary
- add home page with specialty icons
- add flashcards page and back link
- filter flashcards by specialty via URL query
- style specialty grid

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687c45ff2fa48328b1ee9e5b50f14d8c