### PR TITLE
Add user profile and stats to home

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,26 @@
         <header>
             <h1>Selecciona una Especialidad</h1>
         </header>
+
+        <section class="user-panel">
+            <div class="user-info">
+                <img id="profile-pic" src="https://via.placeholder.com/80" alt="Foto de perfil">
+                <div class="user-text">
+                    <h2 id="greeting">Hola Fernando</h2>
+                    <button id="change-pic-btn" class="small-btn">Cambiar foto de perfil</button>
+                    <input type="file" id="profile-pic-input" accept="image/*" style="display:none">
+                </div>
+            </div>
+        </section>
+
+        <section class="progress-panel">
+            <canvas id="progress-chart" width="200" height="200"></canvas>
+            <div class="weak-topics">
+                <h3>Temas a reforzar</h3>
+                <ul id="weak-topics-list"></ul>
+            </div>
+        </section>
+
         <main class="specialty-grid">
             <a href="flashcards.html?specialty=medicina-interna" class="specialty-card">
                 <span class="emoji">🩺</span>
@@ -39,5 +59,7 @@
             </a>
         </main>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="app.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -311,3 +311,58 @@ h1 {
     text-decoration: none;
     color: var(--primary-color);
 }
+
+/* User panel */
+.user-panel {
+    background: var(--card-background);
+    padding: 15px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    margin-bottom: 20px;
+}
+
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.user-info img {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.small-btn {
+    font-size: 0.8rem;
+    padding: 5px 10px;
+    border: none;
+    border-radius: var(--border-radius);
+    background-color: var(--secondary-color);
+    color: #fff;
+    cursor: pointer;
+}
+
+/* Progress panel */
+.progress-panel {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 30px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+#progress-chart {
+    max-width: 200px;
+    max-height: 200px;
+}
+
+.weak-topics ul {
+    list-style: disc inside;
+    padding-left: 0;
+}
+
+.weak-topics li {
+    margin-bottom: 5px;
+}


### PR DESCRIPTION
## Summary
- show new user panel on the home page with greeting and profile picture
- display a pie chart with flashcard progress and list of weak topics
- style the user and progress panels
- handle profile picture upload and home/flashcard page initialization logic

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_687c4a660a0c8328a179c4fbf8aa5948