### PR TITLE
Implement flashcard categories and UI improvements

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ let flashcards = [
         answer: "Es una condición médica en la que la presión arterial es persistentemente elevada, generalmente definida como una presión sistólica de 140 mmHg o más y/o una presión diastólica de 90 mmHg o más.",
         specialty: "medicina-interna",
         difficulty: "medium",
+        category: "definicion",
         lastReviewed: null,
         nextReview: null,
         reviewCount: 0
@@ -14,6 +15,7 @@ let flashcards = [
         answer: "1. Temperatura corporal\n2. Frecuencia cardíaca (pulso)\n3. Presión arterial\n4. Frecuencia respiratoria\n5. Saturación de oxígeno",
         specialty: "medicina-interna",
         difficulty: "easy",
+        category: "diagnostico",
         lastReviewed: null,
         nextReview: null,
         reviewCount: 0
@@ -23,6 +25,7 @@ let flashcards = [
         answer: "Es un trastorno hormonal causado por la exposición prolongada a niveles altos de cortisol. Los síntomas incluyen obesidad central, cara de luna llena, joroba de búfalo, estrías violáceas, hipertensión y diabetes mellitus.",
         specialty: "medicina-interna",
         difficulty: "hard",
+        category: "fisiopatologia",
         lastReviewed: null,
         nextReview: null,
         reviewCount: 0
@@ -32,6 +35,7 @@ let flashcards = [
         answer: "Virus sincitial respiratorio",
         specialty: "pediatria",
         difficulty: "medium",
+        category: "etiologia",
         lastReviewed: null,
         nextReview: null,
         reviewCount: 0
@@ -41,6 +45,7 @@ let flashcards = [
         answer: "Entre las semanas 24 y 28 de gestación.",
         specialty: "gineco-obstetricia",
         difficulty: "medium",
+        category: "diagnostico",
         lastReviewed: null,
         nextReview: null,
         reviewCount: 0
@@ -50,6 +55,7 @@ let flashcards = [
         answer: "Dolor en cuadrante superior derecho, fiebre y leucocitosis.",
         specialty: "cirugia",
         difficulty: "medium",
+        category: "cuadro-clinico",
         lastReviewed: null,
         nextReview: null,
         reviewCount: 0
@@ -59,6 +65,7 @@ let flashcards = [
         answer: "A - Vía aérea con control cervical, B - Respiración, C - Circulación, D - Déficit neurológico, E - Exposición.",
         specialty: "atls",
         difficulty: "easy",
+        category: "tratamiento",
         lastReviewed: null,
         nextReview: null,
         reviewCount: 0
@@ -68,6 +75,37 @@ let flashcards = [
         answer: "1 mg IV cada 3-5 minutos.",
         specialty: "acls",
         difficulty: "easy",
+        category: "tratamiento",
+        lastReviewed: null,
+        nextReview: null,
+        reviewCount: 0
+    },
+    {
+        question: "¿Qué es la diabetes mellitus tipo 1?",
+        answer: "Enfermedad autoinmune caracterizada por destrucción de las células beta pancreáticas y deficiencia absoluta de insulina.",
+        specialty: "medicina-interna",
+        difficulty: "medium",
+        category: "definicion",
+        lastReviewed: null,
+        nextReview: null,
+        reviewCount: 0
+    },
+    {
+        question: "¿Edad más frecuente de presentación del cáncer testicular?",
+        answer: "Entre los 15 y 35 años de edad.",
+        specialty: "cirugia",
+        difficulty: "medium",
+        category: "epidemiologia",
+        lastReviewed: null,
+        nextReview: null,
+        reviewCount: 0
+    },
+    {
+        question: "¿Cuál es la complicación más grave de la influenza?",
+        answer: "Neumonía viral o sobreinfección bacteriana severa.",
+        specialty: "pediatria",
+        difficulty: "medium",
+        category: "complicaciones",
         lastReviewed: null,
         nextReview: null,
         reviewCount: 0
@@ -89,6 +127,7 @@ const addCardBtn = document.getElementById('add-card-btn');
 const newQuestionInput = document.getElementById('new-question');
 const newAnswerInput = document.getElementById('new-answer');
 const newSpecialtySelect = document.getElementById('new-specialty');
+const newCategorySelect = document.getElementById('new-category');
 const editCardBtn = document.getElementById('edit-card-btn');
 const deleteCardBtn = document.getElementById('delete-card-btn');
 const exportBtn = document.getElementById('export-btn');
@@ -115,11 +154,18 @@ let pendingCards = 0;
 let newCards = 0;
 let isFlipped = false;
 
+function updateThemeIcon(isDark) {
+    if (!themeToggle) return;
+    themeToggle.textContent = isDark ? '☀️' : '🌙';
+}
+
 function loadTheme() {
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme === 'dark') {
         document.body.classList.add('dark-mode');
-        if (themeToggle) themeToggle.textContent = 'Modo Día';
+        updateThemeIcon(true);
+    } else {
+        updateThemeIcon(false);
     }
 }
 
@@ -131,7 +177,7 @@ function getQueryParam(name) {
 function toggleTheme() {
     const isDark = document.body.classList.toggle('dark-mode');
     localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    themeToggle.textContent = isDark ? 'Modo Día' : 'Modo Noche';
+    updateThemeIcon(isDark);
 }
 
 // Profile picture handling
@@ -289,6 +335,7 @@ function initHomePage() {
         });
         userNameInput.addEventListener('change', handleNameChange);
     }
+    if (themeToggle) themeToggle.addEventListener('click', toggleTheme);
 }
 
 // Load flashcards from localStorage or use sample data
@@ -341,11 +388,17 @@ function showCard() {
         answerElement.textContent = "";
         return;
     }
-    
+
     const currentCard = flashcards[currentCardIndex];
     questionElement.textContent = currentCard.question;
     answerElement.textContent = currentCard.answer;
-    
+
+    const categories = ['definicion','epidemiologia','etiologia','fisiopatologia','cuadro-clinico','diagnostico','tratamiento','complicaciones'];
+    categories.forEach(c => flashcard.classList.remove(c));
+    if (currentCard.category) {
+        flashcard.classList.add(currentCard.category);
+    }
+
     // Reset card to front
     if (isFlipped) {
         flashcard.classList.remove('flipped');
@@ -440,13 +493,15 @@ function addNewCard() {
     const question = newQuestionInput.value.trim();
     const answer = newAnswerInput.value.trim();
     const specialty = newSpecialtySelect ? newSpecialtySelect.value : '';
+    const category = newCategorySelect ? newCategorySelect.value : '';
 
-    if (question && answer && specialty) {
+    if (question && answer && specialty && category) {
         const newCard = {
             question,
             answer,
             specialty,
             difficulty: 'medium',
+            category,
             lastReviewed: null,
             nextReview: null,
             reviewCount: 0
@@ -467,7 +522,7 @@ function addNewCard() {
         currentCardIndex = flashcards.length - 1;
         showCard();
     } else {
-        alert('Por favor ingresa la pregunta, la respuesta y la especialidad.');
+        alert('Por favor ingresa la pregunta, la respuesta, la especialidad y el rubro.');
     }
 }
 

--- a/flashcards.html
+++ b/flashcards.html
@@ -13,7 +13,7 @@
             <h1>Repaso de Tarjetas Médicas</h1>
             <h2 id="specialty-title"></h2>
             <a href="index.html" class="back-link">&larr; Inicio</a>
-            <button id="theme-toggle" class="theme-toggle">Modo Noche</button>
+            <button id="theme-toggle" class="theme-toggle">🌙</button>
             <div class="stats">
                 <div class="stat-card">
                     <span class="stat-number" id="today-count">0</span>
@@ -72,6 +72,19 @@
             </div>
             <div class="form-group">
                 <textarea id="new-answer" placeholder="Respuesta" class="form-textarea"></textarea>
+            </div>
+            <div class="form-group">
+                <select id="new-category" class="form-input">
+                    <option value="">Rubro</option>
+                    <option value="definicion">Definición</option>
+                    <option value="epidemiologia">Epidemiología</option>
+                    <option value="etiologia">Etiología</option>
+                    <option value="fisiopatologia">Fisiopatología</option>
+                    <option value="cuadro-clinico">Cuadro Clínico</option>
+                    <option value="diagnostico">Diagnóstico</option>
+                    <option value="tratamiento">Tratamiento</option>
+                    <option value="complicaciones">Complicaciones</option>
+                </select>
             </div>
             <div class="form-group">
                 <select id="new-specialty" class="form-input">

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <button id="theme-toggle" class="theme-toggle">🌙</button>
     <div class="container home">
         <header>
             <h1>Selecciona una Especialidad</h1>

--- a/styles.css
+++ b/styles.css
@@ -56,11 +56,17 @@ h1 {
     background-color: var(--secondary-color);
     color: white;
     border: none;
-    padding: 8px 16px;
-    border-radius: var(--border-radius);
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
     cursor: pointer;
-    font-size: 0.9rem;
-    margin-bottom: 15px;
+    font-size: 1.2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 20px;
+    right: 20px;
 }
 
 .stats {
@@ -94,7 +100,7 @@ h1 {
 .flashcard-container {
     perspective: 1000px;
     margin: 30px 0;
-    height: 300px;
+    height: 400px;
 }
 
 .flashcard {
@@ -132,6 +138,7 @@ h1 {
     border-radius: var(--border-radius);
     box-shadow: var(--box-shadow);
     background: var(--card-background);
+    font-size: 1.2rem;
 }
 
 .flashcard-back {
@@ -380,3 +387,16 @@ h1 {
 .weak-topics li {
     margin-bottom: 5px;
 }
+
+/* Category borders */
+.flashcard {
+    border: 4px solid transparent;
+}
+.flashcard.definicion { border-color: #007bff; }
+.flashcard.epidemiologia { border-color: #17a2b8; }
+.flashcard.etiologia { border-color: #6f42c1; }
+.flashcard.fisiopatologia { border-color: #fd7e14; }
+.flashcard.cuadro-clinico { border-color: #28a745; }
+.flashcard.diagnostico { border-color: #ffc107; }
+.flashcard.tratamiento { border-color: #dc3545; }
+.flashcard.complicaciones { border-color: #343a40; }


### PR DESCRIPTION
## Summary
- add demo flashcards with category metadata
- allow selecting category when creating cards
- display colored border on flashcard according to category
- enlarge review card layout and show day/night toggle icon on both pages
- position theme toggle in corner and use sun/moon icons

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687c5186b74483289bb21d88933a2587