### PR TITLE
Add dashboard cards and progress donut components

### DIFF
--- a/components/LibraryCard.jsx
+++ b/components/LibraryCard.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { BookOpen, ChevronRight } from 'lucide-react';
+
+const LibraryCard = () => (
+  <div className="flex items-center justify-between p-5 rounded-2xl border">
+    <div className="flex items-center space-x-3">
+      <div className="p-2 rounded-full bg-emerald-50 text-emerald-500">
+        <BookOpen size={20} />
+      </div>
+      <div>
+        <p className="font-medium">Biblioteca Médica</p>
+        <p className="text-sm text-gray-500">Resúmenes clínicos ENARM</p>
+      </div>
+    </div>
+    <ChevronRight className="text-gray-400" />
+  </div>
+);
+
+export default LibraryCard;

--- a/components/ProgressDonut.jsx
+++ b/components/ProgressDonut.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { PieChart, Pie, Cell } from "recharts";
+
+const renderLegend = (data) => (
+  <ul className="space-y-1 ml-4">
+    {data.map((entry) => (
+      <li key={entry.name} className="flex items-center text-sm">
+        <span className="w-2 h-2 rounded-full mr-2" style={{backgroundColor: entry.color}}></span>
+        {entry.name}
+      </li>
+    ))}
+  </ul>
+);
+
+const ProgressDonut = ({ data }) => (
+  <div className="bg-white rounded-2xl border p-5 flex items-center space-x-4">
+    <PieChart width={140} height={140}>
+      <Pie
+        data={data}
+        dataKey="value"
+        nameKey="name"
+        innerRadius={50}
+        outerRadius={65}
+        paddingAngle={3}
+      >
+        {data.map((entry) => (
+          <Cell key={entry.name} fill={entry.color} />
+        ))}
+      </Pie>
+    </PieChart>
+    {renderLegend(data)}
+  </div>
+);
+
+export default ProgressDonut;

--- a/components/QuestionBankCard.jsx
+++ b/components/QuestionBankCard.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FileQuestion, ChevronRight } from 'lucide-react';
+
+const QuestionBankCard = () => {
+  const navigate = useNavigate();
+  return (
+    <div
+      onClick={() => navigate('/quiz')}
+      className="cursor-pointer flex items-center justify-between p-5 rounded-2xl border bg-white hover:bg-gray-50"
+    >
+      <div className="flex items-center space-x-3">
+        <div className="p-2 rounded-full bg-orange-50 text-orange-500">
+          <FileQuestion size={20} />
+        </div>
+        <div>
+          <p className="font-medium">Banco de Preguntas</p>
+          <p className="text-sm text-gray-500">Cuestionario adaptativo</p>
+        </div>
+      </div>
+      <ChevronRight className="text-gray-400" />
+    </div>
+  );
+};
+
+export default QuestionBankCard;

--- a/components/RecentActivityCard.jsx
+++ b/components/RecentActivityCard.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { CheckCircleIcon } from '@heroicons/react/solid';
+
+function timeAgo(date) {
+  const diff = Math.floor((Date.now() - new Date(date)) / 1000);
+  const minutes = Math.floor(diff / 60);
+  const hours = Math.floor(minutes / 60);
+  if (hours > 0) return `hace ${hours}h`;
+  if (minutes > 0) return `hace ${minutes}m`;
+  return 'recién';
+}
+
+const RecentActivityCard = ({ title, type, completedAt }) => (
+  <div className="h-56 rounded-2xl shadow-xl text-white p-6 flex flex-col justify-between" style={{background: 'radial-gradient(circle, var(--tw-gradient-stops))', '--tw-gradient-from': 'rgb(79 70 229)', '--tw-gradient-to': 'rgb(55 48 163)'}}>
+    <div>
+      <h3 className="text-xl font-semibold">{title}</h3>
+      <p className="text-sm opacity-90">{type}</p>
+    </div>
+    <div className="space-y-4">
+      <span className="inline-flex items-center text-sm bg-green-500 bg-opacity-20 text-green-200 px-3 py-1 rounded-full">
+        <CheckCircleIcon className="w-4 h-4 mr-1" />
+        Completado: {timeAgo(completedAt)}
+      </span>
+      <button className="w-full py-2 rounded-lg bg-indigo-500 hover:bg-indigo-400 transition-colors">Continuar</button>
+    </div>
+  </div>
+);
+
+export default RecentActivityCard;


### PR DESCRIPTION
## Summary
- add `RecentActivityCard` component with radial gradient background
- add `LibraryCard` component with book icon
- add `ProgressDonut` component using recharts
- add `QuestionBankCard` component to navigate to quiz

## Testing
- `node -e "require('./components/RecentActivityCard.jsx');"` *(fails: Unexpected token due to missing JSX loader)*

------
https://chatgpt.com/codex/tasks/task_e_687c571ba1c88328b0623b30f3e66080