### PR TITLE
Add study heatmap components and stats

### DIFF
--- a/__tests__/StudyHeatmap.test.tsx
+++ b/__tests__/StudyHeatmap.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import StudyHeatmap from '../src/components/StudyHeatmap';
+import { getStreak } from '../src/components/StatsSidebar';
+
+describe('StudyHeatmap', () => {
+  test('renderiza 365 celdas', () => {
+    const start = new Date('2023-01-01');
+    const data = Array.from({ length: 365 }, (_, i) => ({ date: new Date(start.getTime() + i * 86400000), reviews: 0 }));
+    render(<StudyHeatmap data={data} startDate={start} endDate={new Date(start.getTime() + 364 * 86400000)} />);
+    const cells = screen.getAllByRole('list')[0].querySelectorAll('rect');
+    expect(cells.length).toBe(365);
+  });
+
+  test('celdas con reviews>10 tienen clase bg-emerald-700', () => {
+    const data = [{ date: new Date(), reviews: 11 }];
+    render(<StudyHeatmap data={data} />);
+    const cell = screen.getByLabelText(/repasos el/);
+    expect(cell).toHaveAttribute('fill', '#059669');
+  });
+});
+
+describe('getStreak', () => {
+  test('sin actividad devuelve 0', () => {
+    expect(getStreak([]).current).toBe(0);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "enarmax",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-calendar-heatmap": "^1.8.0",
+    "firebase": "^9.23.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.0.0",
+    "@types/jest": "^29.5.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/src/components/StatsSidebar.tsx
+++ b/src/components/StatsSidebar.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+export interface StatsSidebarProps {
+  data: { date: Date; reviews: number; accuracy?: number }[];
+}
+
+/** Calcula el streak actual y máximo. */
+export const getStreak = (data: { date: Date; reviews: number }[]) => {
+  const sorted = [...data].sort((a, b) => a.date.getTime() - b.date.getTime());
+  let current = 0;
+  let max = 0;
+  let prev: Date | null = null;
+  for (const d of sorted) {
+    if (prev && Math.floor((d.date.getTime() - prev.getTime()) / 86400000) === 1) {
+      current++;
+    } else if (!prev || d.date.getTime() - prev.getTime() > 86400000) {
+      current = 1;
+    }
+    max = Math.max(max, current);
+    prev = d.date;
+  }
+  const lastDate = sorted[sorted.length - 1];
+  const today = new Date();
+  if (!lastDate || Math.floor((today.getTime() - lastDate.date.getTime()) / 86400000) > 1) {
+    current = 0;
+  }
+  return { current, max };
+};
+
+/** Barra lateral con métricas de estudio. */
+export const StatsSidebar: React.FC<StatsSidebarProps> = ({ data }) => {
+  const { current, max } = getStreak(data);
+  const total = data.reduce((s, d) => s + d.reviews, 0);
+  const accuracies = data.map((d) => d.accuracy).filter((v): v is number => typeof v === 'number');
+  const accuracy = accuracies.length ? accuracies.reduce((s, a) => s + a, 0) / accuracies.length : undefined;
+
+  return (
+    <aside className="p-4 space-y-2" aria-label="Estadísticas de estudio">
+      <div>Racha actual: {current} días</div>
+      <div>Racha máxima: {max} días</div>
+      <div>Total repasos: {total}</div>
+      {typeof accuracy === 'number' && <div>Exactitud promedio: {accuracy.toFixed(1)}%</div>}
+    </aside>
+  );
+};
+
+export default StatsSidebar;

--- a/src/components/StudyHeatmap.tsx
+++ b/src/components/StudyHeatmap.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { ResponsiveCalendarHeatmap, CalendarDatum } from 'react-calendar-heatmap';
+
+export interface StudyHeatmapProps {
+  data: { date: string | Date; reviews: number; accuracy?: number }[];
+  startDate?: Date;
+  endDate?: Date;
+  onCellClick?: (d: { date: Date; reviews: number }) => void;
+}
+
+const colorScale = (v: number, dark?: boolean) => {
+  if (v === 0) return dark ? '#e0e7ff' : '#e5f9ef';
+  if (v <= 5) return dark ? '#a5b4fc' : '#a7f3d0';
+  if (v <= 10) return dark ? '#6366f1' : '#34d399';
+  return dark ? '#4338ca' : '#059669';
+};
+
+/**
+ * Heatmap de actividad de estudio tipo GitHub.
+ * @param props {@link StudyHeatmapProps}
+ */
+export const StudyHeatmap: React.FC<StudyHeatmapProps> = ({
+  data,
+  startDate = new Date(Date.now() - 364 * 24 * 60 * 60 * 1000),
+  endDate = new Date(),
+  onCellClick,
+}) => {
+  const values: CalendarDatum[] = data.map((d) => ({
+    date: typeof d.date === 'string' ? d.date : d.date.toISOString().split('T')[0],
+    count: d.reviews,
+    accuracy: d.accuracy,
+  }));
+
+  return (
+    <ResponsiveCalendarHeatmap
+      data={values}
+      from={startDate.toISOString().split('T')[0]}
+      to={endDate.toISOString().split('T')[0]}
+      emptyColor={colorScale(0)}
+      colors={[colorScale(1), colorScale(6), colorScale(11)]}
+      width="100%"
+      height={140}
+      gutterSize={4}
+      tooltip={(d) =>
+        `${d.count} repasos el ${new Date(d.date).toLocaleDateString()}${
+          typeof d.accuracy === 'number' ? `\n${d.accuracy.toFixed(0)}% acierto` : ''
+        }`
+      }
+      onClick={(d) => onCellClick?.({ date: new Date(d.date), reviews: d.count })}
+      role="list"
+      cellComponent={({ value, x, y, size, color }) => (
+        <rect
+          x={x}
+          y={y}
+          width={size}
+          height={size}
+          fill={color}
+          aria-label={`${value?.count ?? 0} repasos el ${new Date(value?.date ?? '').toLocaleDateString()}`}
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onCellClick?.({ date: new Date(value!.date), reviews: value!.count });
+          }}
+          className="focus:outline-none focus-visible:ring-2"
+        />
+      )}
+    />
+  );
+};
+export default StudyHeatmap;

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,10 @@
+// Firebase initialization placeholder
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  // configuration
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/src/hooks/useReviewStats.tsx
+++ b/src/hooks/useReviewStats.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+import StudyHeatmap from '../components/StudyHeatmap';
+import StatsSidebar from '../components/StatsSidebar';
+
+export interface ReviewStat {
+  date: Date;
+  reviews: number;
+  accuracy?: number;
+}
+
+/**
+ * Obtiene estadísticas de revisión desde Firestore.
+ */
+export const useReviewStats = (userId: string, startDate: Date) => {
+  const [data, setData] = useState<ReviewStat[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const q = query(collection(db, 'reviews'), where('userId', '==', userId), where('date', '>=', startDate));
+      const snap = await getDocs(q);
+      const byDate: Record<string, { correct: number; total: number }> = {};
+      snap.forEach((doc) => {
+        const { date, correct, total } = doc.data();
+        const key = date.split('T')[0];
+        if (!byDate[key]) byDate[key] = { correct: 0, total: 0 };
+        byDate[key].correct += correct;
+        byDate[key].total += total;
+      });
+      const result: ReviewStat[] = Object.entries(byDate).map(([d, v]) => ({
+        date: new Date(d),
+        reviews: v.total,
+        accuracy: (v.correct / v.total) * 100,
+      }));
+      setData(result);
+    };
+    fetchData();
+  }, [userId, startDate]);
+
+  return data;
+};
+
+export const ReviewStats: React.FC<{ userId: string; startDate: Date }> = ({ userId, startDate }) => {
+  const data = useReviewStats(userId, startDate);
+
+  return (
+    <div className="flex">
+      <StudyHeatmap data={data} />
+      <StatsSidebar data={data} />
+    </div>
+  );
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "es2017",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "__tests__/**/*"]
+}


### PR DESCRIPTION
## Summary
- add StudyHeatmap component using `react-calendar-heatmap`
- add StatsSidebar with streak and accuracy metrics
- provide hook `useReviewStats` to load stats from Firestore
- include Firebase initialization placeholder
- configure TypeScript and Jest
- add tests for heatmap cells and streak selector

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c5b367af8832896783f07a633b1f2