### PR TITLE
Add heatmap stats module

### DIFF
--- a/src/components/StatsSidebar.tsx
+++ b/src/components/StatsSidebar.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ReviewStats } from '../hooks/useReviewStats';
+
+interface Props {
+  stats: ReviewStats;
+}
+
+const StatsSidebar: React.FC<Props> = ({ stats }) => (
+  <aside className="space-y-4">
+    <div className="p-4 rounded-lg bg-white dark:bg-gray-800">
+      <p className="text-sm text-gray-500 dark:text-gray-400">Racha activa</p>
+      <p className="text-2xl font-semibold">{stats.streak} días</p>
+    </div>
+    <div className="p-4 rounded-lg bg-white dark:bg-gray-800">
+      <p className="text-sm text-gray-500 dark:text-gray-400">Mejor racha</p>
+      <p className="text-2xl font-semibold">{stats.maxStreak} días</p>
+    </div>
+    <div className="p-4 rounded-lg bg-white dark:bg-gray-800">
+      <p className="text-sm text-gray-500 dark:text-gray-400">Total repasos</p>
+      <p className="text-2xl font-semibold">{stats.totalReviews}</p>
+    </div>
+    <div className="p-4 rounded-lg bg-white dark:bg-gray-800">
+      <p className="text-sm text-gray-500 dark:text-gray-400">Exactitud promedio</p>
+      <p className="text-2xl font-semibold">{stats.averageAccuracy.toFixed(1)}%</p>
+    </div>
+  </aside>
+);
+
+export default StatsSidebar;

--- a/src/components/StudyHeatmap.test.tsx
+++ b/src/components/StudyHeatmap.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import StudyHeatmap, { ReviewDay } from './StudyHeatmap';
+
+describe('StudyHeatmap', () => {
+  test('renderiza 365 celdas', () => {
+    const today = new Date();
+    const data: ReviewDay[] = [];
+    for (let i = 0; i < 365; i++) {
+      data.push({ date: new Date(today.getTime() - i * 86400000), reviews: 0 });
+    }
+    const { container } = render(<StudyHeatmap data={data} />);
+    expect(container.querySelectorAll('[data-testid="heatmap-cell"]').length).toBe(365);
+  });
+
+  test('celdas con >10 repasos usan color oscuro', () => {
+    const data: ReviewDay[] = [
+      { date: new Date(), reviews: 11 },
+    ];
+    const { container } = render(<StudyHeatmap data={data} />);
+    const cell = container.querySelector('[data-testid="heatmap-cell"]');
+    expect(cell?.className).toContain('bg-emerald-700');
+  });
+});

--- a/src/components/StudyHeatmap.tsx
+++ b/src/components/StudyHeatmap.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import CalendarHeatmap from 'react-calendar-heatmap';
+import { format } from 'date-fns';
+
+export interface ReviewDay {
+  date: string | Date;
+  reviews: number;
+  accuracy?: number;
+}
+
+export interface StudyHeatmapProps {
+  data: ReviewDay[];
+  onCellClick?: (day: ReviewDay) => void;
+}
+
+function classForValue(value?: { count: number }): string {
+  if (!value || value.count === 0) return 'bg-emerald-50 dark:bg-indigo-50';
+  if (value.count <= 5) return 'bg-emerald-300 dark:bg-indigo-300';
+  if (value.count <= 10) return 'bg-emerald-500 dark:bg-indigo-500';
+  return 'bg-emerald-700 dark:bg-indigo-700';
+}
+
+const StudyHeatmap: React.FC<StudyHeatmapProps> = ({ data, onCellClick }) => {
+  const today = new Date();
+  const startDate = new Date(today.getTime() - 364 * 86400000);
+
+  const values = data.map((d) => ({
+    date: typeof d.date === 'string' ? d.date : d.date.toISOString().slice(0, 10),
+    count: d.reviews,
+    accuracy: d.accuracy,
+  }));
+
+  return (
+    <div className="w-full" style={{ height: '140px' }}>
+      <CalendarHeatmap
+        startDate={startDate}
+        endDate={today}
+        values={values}
+        gutterSize={4}
+        classForValue={classForValue}
+        titleForValue={(value) => {
+          if (!value || !value.date) return '0 repasos';
+          const accuracy = value.accuracy !== undefined ? `, ${value.accuracy}%` : '';
+          return `${value.count} repasos${accuracy}`;
+        }}
+        ariaLabelForValue={(value) => {
+          if (!value || !value.date) return '0 repasos';
+          const date = format(new Date(value.date), 'dd/MM/yyyy');
+          return `${value.count} repasos el ${date}`;
+        }}
+        onClick={(value) => {
+          if (onCellClick && value && value.date) {
+            const original = data.find(
+              (d) => (typeof d.date === 'string' ? d.date : d.date.toISOString().slice(0, 10)) === value.date,
+            );
+            if (original) onCellClick(original);
+          }
+        }}
+        // data-testid is added through transformDayElement
+        transformDayElement={(el, value) => {
+          return React.cloneElement(el, { 'data-testid': 'heatmap-cell', tabIndex: 0 });
+        }}
+      />
+    </div>
+  );
+};
+
+export default StudyHeatmap;

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,10 @@
+// Placeholder Firestore initialization
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  // Your config here
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/src/hooks/useReviewStats.ts
+++ b/src/hooks/useReviewStats.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+import { calculateStreaks } from '../utils/stats';
+import { ReviewDay } from '../components/StudyHeatmap';
+
+export interface ReviewStats {
+  data: ReviewDay[];
+  totalReviews: number;
+  averageAccuracy: number;
+  streak: number;
+  maxStreak: number;
+}
+
+export function useReviewStats(userId: string): ReviewStats {
+  const [stats, setStats] = useState<ReviewStats>({
+    data: [],
+    totalReviews: 0,
+    averageAccuracy: 0,
+    streak: 0,
+    maxStreak: 0,
+  });
+
+  useEffect(() => {
+    async function fetchData() {
+      const end = new Date();
+      const start = new Date(end.getTime() - 364 * 86400000);
+      const q = query(
+        collection(db, 'reviews'),
+        where('userId', '==', userId),
+        where('date', '>=', start),
+        where('date', '<=', end),
+      );
+      const snap = await getDocs(q);
+      const map: Record<string, ReviewDay> = {};
+      snap.forEach((doc) => {
+        const d = doc.data();
+        const day = new Date(d.date.seconds ? d.date.seconds * 1000 : d.date);
+        const key = day.toISOString().slice(0, 10);
+        if (!map[key]) {
+          map[key] = { date: key, reviews: 0, accuracy: 0 };
+        }
+        map[key].reviews += d.reviews;
+        if (d.accuracy !== undefined) {
+          map[key].accuracy = ((map[key].accuracy || 0) + d.accuracy) / 2;
+        }
+      });
+      const data = Object.values(map).sort((a, b) => (a.date > b.date ? 1 : -1));
+      const totalReviews = data.reduce((sum, d) => sum + d.reviews, 0);
+      const allAccuracy = data.filter((d) => d.accuracy !== undefined);
+      const averageAccuracy = allAccuracy.length
+        ? allAccuracy.reduce((sum, d) => sum + (d.accuracy || 0), 0) / allAccuracy.length
+        : 0;
+      const { current, max } = calculateStreaks(data.map((d) => ({ date: new Date(d.date), reviews: d.reviews })));
+      setStats({ data, totalReviews, averageAccuracy, streak: current, maxStreak: max });
+    }
+    fetchData();
+  }, [userId]);
+
+  return stats;
+}

--- a/src/utils/stats.test.ts
+++ b/src/utils/stats.test.ts
@@ -1,0 +1,7 @@
+import { calculateStreaks, SimpleDay } from './stats';
+
+describe('calculateStreaks', () => {
+  test('sin actividad devuelve 0', () => {
+    expect(calculateStreaks([]).current).toBe(0);
+  });
+});

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,0 +1,28 @@
+export interface SimpleDay {
+  date: Date;
+  reviews: number;
+}
+
+export function calculateStreaks(days: SimpleDay[]): { current: number; max: number } {
+  if (days.length === 0) return { current: 0, max: 0 };
+  const sorted = days
+    .filter((d) => d.reviews > 0)
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+  if (sorted.length === 0) return { current: 0, max: 0 };
+  let current = 1;
+  let max = 1;
+  for (let i = 1; i < sorted.length; i++) {
+    const diff = (sorted[i].date.getTime() - sorted[i - 1].date.getTime()) / 86400000;
+    if (diff === 1) {
+      current += 1;
+    } else if (diff > 1) {
+      if (current > max) max = current;
+      current = 1;
+    }
+  }
+  if (current > max) max = current;
+
+  const lastDiff = (new Date().setHours(0, 0, 0, 0) - sorted[sorted.length - 1].date.setHours(0, 0, 0, 0)) / 86400000;
+  const activeStreak = lastDiff === 0 ? current : 0;
+  return { current: activeStreak, max };
+}


### PR DESCRIPTION
## Summary
- implement StudyHeatmap React component for advanced statistics
- implement StatsSidebar and review stats hook
- add streak calculation helper
- provide placeholder Firebase config
- add unit tests for heatmap and streak functions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c5e510af48328b1d546a0eb45e7f4