### PR TITLE
Add Study Heatmap component

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,11 @@
             </div>
         </section>
 
+        <section class="heatmap-panel">
+            <div id="study-heatmap" class="study-heatmap"></div>
+            <div id="heatmap-metrics" class="heatmap-metrics"></div>
+        </section>
+
         <main class="specialty-grid" id="specialty-grid">
         </main>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -400,3 +400,57 @@ h1 {
 .flashcard.diagnostico { border-color: #ffc107; }
 .flashcard.tratamiento { border-color: #dc3545; }
 .flashcard.complicaciones { border-color: #343a40; }
+
+/* Study heatmap */
+.heatmap-panel {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+    margin-bottom: 30px;
+    flex-wrap: wrap;
+}
+
+.study-heatmap .months {
+    display: grid;
+    grid-template-columns: repeat(53, 12px);
+    font-size: 0.7rem;
+    margin-left: 20px;
+    margin-bottom: 4px;
+    gap: 2px;
+    text-align: center;
+}
+
+.study-heatmap .cells {
+    display: grid;
+    grid-template-rows: repeat(7, 12px);
+    grid-template-columns: repeat(53, 12px);
+    gap: 2px;
+}
+
+.heatmap-cell {
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+}
+
+.heatmap-cell:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 1px;
+}
+
+.level-0 { background-color: #e6f4ea; }
+.level-1 { background-color: #b7e4c7; }
+.level-2 { background-color: #52b788; }
+.level-3 { background-color: #2d6a4f; }
+
+body.dark-mode .level-0 { background-color: #e0e7ff; }
+body.dark-mode .level-1 { background-color: #a5b4fc; }
+body.dark-mode .level-2 { background-color: #6366f1; }
+body.dark-mode .level-3 { background-color: #4338ca; }
+
+.heatmap-metrics {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.9rem;
+    gap: 4px;
+}


### PR DESCRIPTION
## Summary
- add heatmap panel on home page
- style heatmap grid and metrics
- track review history in `localStorage`
- render heatmap and metrics
- hook review flow to update heatmap

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden, offline)*

------
https://chatgpt.com/codex/tasks/task_e_687c66a74b708328b6828591eab27d8b