### PR TITLE
Add cloze card creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ No se requieren dependencias externas ni servidores adicionales; todo funciona d
 - `index.html` – Página principal de la aplicación.
 - `styles.css` – Hojas de estilo con el diseño de la interfaz.
 - `app.js` – Lógica de las tarjetas y manejo de eventos.
+- `cloze.html` – Formulario para crear tarjetas tipo cloze.
+- `cloze.js` – Lógica de previsualización y guardado de las tarjetas cloze.
 
 ## Contribuciones
 

--- a/cloze.html
+++ b/cloze.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Crear Tarjeta Cloze</title>
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Crear Tarjeta Cloze</h1>
+            <a href="index.html" class="back-link">&larr; Inicio</a>
+        </header>
+
+        <form id="cloze-form" class="add-card-form">
+            <div class="form-group">
+                <input type="text" id="cloze-title" placeholder="Título de la tarjeta" class="form-input">
+                <div class="error" id="title-error"></div>
+            </div>
+            <div class="form-group">
+                <textarea id="cloze-text" placeholder="Escribe la frase con omisiones usando {{ }}." class="form-textarea"></textarea>
+                <div class="error" id="text-error"></div>
+            </div>
+            <button id="preview-btn" class="small-btn" type="button">Previsualizar</button>
+            <button id="save-btn" class="small-btn" type="button">Guardar</button>
+        </form>
+
+        <div id="preview-area" class="preview-area"></div>
+    </div>
+
+    <script src="cloze.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('sw.js');
+        }
+    </script>
+</body>
+</html>

--- a/cloze.js
+++ b/cloze.js
@@ -1,0 +1,53 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const titleInput = document.getElementById('cloze-title');
+    const textInput = document.getElementById('cloze-text');
+    const previewArea = document.getElementById('preview-area');
+    const previewBtn = document.getElementById('preview-btn');
+    const saveBtn = document.getElementById('save-btn');
+    const titleError = document.getElementById('title-error');
+    const textError = document.getElementById('text-error');
+
+    const hasCloze = str => /\{\{[^}]+\}\}/.test(str);
+
+    function renderPreview() {
+        const text = textInput.value;
+        previewArea.innerHTML = '';
+        titleError.textContent = '';
+        textError.textContent = '';
+        if (!hasCloze(text)) {
+            textError.textContent = 'Debes marcar al menos una omisión';
+            return;
+        }
+        const html = text.replace(/\{\{[^}]+\}\}/g, '<span class="cloze-blank">______</span>');
+        previewArea.innerHTML = html;
+    }
+
+    previewBtn.addEventListener('click', e => {
+        e.preventDefault();
+        renderPreview();
+    });
+
+    saveBtn.addEventListener('click', e => {
+        e.preventDefault();
+        let valid = true;
+        titleError.textContent = '';
+        textError.textContent = '';
+        const title = titleInput.value.trim();
+        const text = textInput.value;
+        if (!title) {
+            titleError.textContent = 'El título es obligatorio';
+            valid = false;
+        }
+        if (!hasCloze(text)) {
+            textError.textContent = 'Debes marcar al menos una omisión';
+            valid = false;
+        }
+        if (!valid) return;
+        const cards = JSON.parse(localStorage.getItem('clozeCards') || '[]');
+        cards.push({ title, text });
+        localStorage.setItem('clozeCards', JSON.stringify(cards));
+        titleInput.value = '';
+        textInput.value = '';
+        previewArea.innerHTML = '';
+    });
+});

--- a/flashcards.html
+++ b/flashcards.html
@@ -62,6 +62,7 @@
                 <button id="export-btn" class="small-btn">Exportar</button>
                 <button id="import-btn" class="small-btn">Importar</button>
                 <input type="file" id="import-input" accept="application/json" style="display:none">
+                <a href="cloze.html" class="small-btn">Crear Cloze</a>
             </div>
         </main>
 

--- a/styles.css
+++ b/styles.css
@@ -454,3 +454,26 @@ body.dark-mode .level-3 { background-color: #4338ca; }
     font-size: 0.9rem;
     gap: 4px;
 }
+
+/* Cloze card creator */
+.preview-area {
+    margin-top: 20px;
+    padding: 15px;
+    border: 1px solid #ddd;
+    border-radius: var(--border-radius);
+    background: var(--card-background-alt);
+    min-height: 50px;
+    white-space: pre-wrap;
+}
+
+.cloze-blank {
+    background-color: #e0e0e0;
+    border-bottom: 2px solid #999;
+    padding: 0 4px;
+}
+
+.error {
+    color: var(--danger-color);
+    font-size: 0.9rem;
+    margin-top: 5px;
+}

--- a/sw.js
+++ b/sw.js
@@ -3,8 +3,10 @@ const ASSETS = [
   '/',
   'index.html',
   'flashcards.html',
+  'cloze.html',
   'styles.css',
   'app.js',
+  'cloze.js',
   'js/chart.min.js'
 ];
 self.addEventListener('install', e => {


### PR DESCRIPTION
## Summary
- implement page to create cloze-style flashcards
- add preview and validation logic
- style preview area and blanks
- link to cloze creator from flashcards page
- update service worker and documentation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c6e609e68832891b59eb3fa468407