### PR TITLE
Add Markdown rendering with media support

### DIFF
--- a/app.js
+++ b/app.js
@@ -561,7 +561,11 @@ function showCard() {
 
     const currentCard = flashcards[currentCardIndex];
     questionElement.textContent = currentCard.question;
-    answerElement.textContent = currentCard.answer;
+    if (typeof window.renderMarkdown === 'function') {
+        window.renderMarkdown(currentCard.answer, answerElement);
+    } else {
+        answerElement.textContent = currentCard.answer;
+    }
 
     const categories = ['definicion','epidemiologia','etiologia','fisiopatologia','cuadro-clinico','diagnostico','tratamiento','complicaciones'];
     categories.forEach(c => flashcard.classList.remove(c));

--- a/flashcards.html
+++ b/flashcards.html
@@ -75,6 +75,11 @@
                 <textarea id="new-answer" placeholder="Respuesta" class="form-textarea"></textarea>
             </div>
             <div class="form-group">
+                <button id="preview-answer-btn" class="small-btn">Previsualizar</button>
+                <a href="guide.html" class="small-btn" target="_blank">Guía de sintaxis</a>
+            </div>
+            <div id="answer-preview" class="preview-area"></div>
+            <div class="form-group">
                 <select id="new-category" class="form-input">
                     <option value="">Rubro</option>
                     <option value="definicion">Definición</option>
@@ -94,6 +99,10 @@
         </div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
+    <script src="main.js"></script>
     <script src="app.js"></script>
     <script>
         if ('serviceWorker' in navigator) {

--- a/guide.html
+++ b/guide.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Guía de sintaxis Markdown</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Guía de Sintaxis</h1>
+    <p>Ejemplos de uso del campo <code>body</code>:</p>
+    <pre>
+![Radiografía de tórax](https://ejemplo.com/rx.jpg)
+
+<audio src="miarchivo.mp3" controls></audio>
+
+$E = mc^2$
+    </pre>
+    <a href="javascript:history.back()">Volver</a>
+  </div>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,89 @@
+(function(){
+  function insertAtCursor(textarea, text) {
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    textarea.setRangeText(text, start, end, 'end');
+    textarea.focus();
+  }
+
+  window.renderMarkdown = function(mdText, container){
+    if(!container){ return; }
+    let text = mdText || '';
+    text = text.replace(/\$\$(.+?)\$\$/gs, '<div class="latex-block">$1</div>');
+    text = text.replace(/\$(.+?)\$/g, '<span class="latex-inline">$1</span>');
+    const html = window.markdownit({html:true}).render(text);
+    const temp = document.createElement('div');
+    temp.innerHTML = html;
+
+    temp.querySelectorAll('img').forEach(img => {
+      img.classList.add('md-image');
+    });
+
+    temp.querySelectorAll('audio').forEach(a => {
+      a.setAttribute('controls', '');
+      a.setAttribute('preload', 'none');
+      a.classList.add('md-audio');
+      a.tabIndex = 0;
+      a.addEventListener('keydown', e => {
+        if(e.code === 'Space' || e.code === 'Enter'){
+          e.preventDefault();
+          if(a.paused) a.play(); else a.pause();
+        }
+      });
+    });
+
+    temp.querySelectorAll('.latex-inline, .latex-block').forEach(el => {
+      try {
+        window.katex.render(el.textContent, el, {
+          throwOnError: false,
+          displayMode: el.classList.contains('latex-block')
+        });
+      } catch(err){
+        el.style.color = 'red';
+        el.setAttribute('aria-label', el.textContent);
+      }
+    });
+
+    container.innerHTML = '';
+    container.append(...temp.childNodes);
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const previewBtn = document.getElementById('preview-answer-btn');
+    const previewArea = document.getElementById('answer-preview');
+    const answerInput = document.getElementById('new-answer');
+
+    if(previewBtn && previewArea && answerInput){
+      previewBtn.addEventListener('click', e => {
+        e.preventDefault();
+        window.renderMarkdown(answerInput.value, previewArea);
+      });
+
+      ['dragover','dragenter'].forEach(ev => {
+        answerInput.addEventListener(ev, e => e.preventDefault());
+      });
+      answerInput.addEventListener('drop', e => {
+        e.preventDefault();
+        Array.from(e.dataTransfer.files).forEach(file => {
+          if(file.size > 5 * 1024 * 1024){
+            alert('Archivo demasiado grande');
+            return;
+          }
+          if(!(file.type.startsWith('image') || file.type.startsWith('audio'))){
+            return;
+          }
+          const reader = new FileReader();
+          reader.onload = ev => {
+            const dataUrl = ev.target.result;
+            try{ localStorage.setItem('mdResource_' + Date.now(), dataUrl); }catch{}
+            const tag = file.type.startsWith('audio')
+              ? `<audio src="${dataUrl}" controls></audio>`
+              : `![${file.name}](${dataUrl})`;
+            insertAtCursor(answerInput, tag);
+          };
+          reader.readAsDataURL(file);
+        });
+      });
+    }
+  });
+})();

--- a/styles.css
+++ b/styles.css
@@ -477,3 +477,22 @@ body.dark-mode .level-3 { background-color: #4338ca; }
     font-size: 0.9rem;
     margin-top: 5px;
 }
+
+/* Markdown media */
+.md-image {
+    max-width: 100%;
+    border-radius: var(--border-radius);
+}
+
+.latex-block {
+    margin: 1em 0;
+}
+
+.md-audio {
+    width: 100%;
+    margin: 10px 0;
+}
+
+body.dark-mode .md-audio {
+    filter: invert(1) hue-rotate(180deg);
+}


### PR DESCRIPTION
## Summary
- support Markdown-based answers with images, audio and LaTeX
- add preview and syntax guide for card creation
- style media blocks
- implement renderMarkdown() helper and local media handling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c6fe275588328999b15cb0c5d0768