### PR TITLE
Add Anki apkg import/export

### DIFF
--- a/app.js
+++ b/app.js
@@ -147,6 +147,9 @@ const deleteCardBtn = document.getElementById('delete-card-btn');
 const exportBtn = document.getElementById('export-btn');
 const importBtn = document.getElementById('import-btn');
 const importInput = document.getElementById('import-input');
+const exportApkgBtn = document.getElementById('export-apkg-btn');
+const importApkgBtn = document.getElementById('import-apkg-btn');
+const importApkgInput = document.getElementById('import-apkg-input');
 const themeToggle = document.getElementById('theme-toggle');
 const specialtyTitle = document.getElementById("specialty-title");
 // Home page elements
@@ -473,6 +476,31 @@ function initFlashcardsPage() {
     if (importBtn && importInput) {
         importBtn.addEventListener('click', () => importInput.click());
         importInput.addEventListener('change', importFlashcards);
+    }
+    if (exportApkgBtn) {
+        exportApkgBtn.addEventListener('click', async () => {
+            const deck = getQueryParam('specialty');
+            const cards = allFlashcards.filter(c => c.specialty === deck);
+            await window.exportDeckToApkg(deck || 'deck', cards);
+        });
+    }
+    if (importApkgBtn && importApkgInput) {
+        importApkgBtn.addEventListener('click', () => importApkgInput.click());
+        importApkgInput.addEventListener('change', async e => {
+            const file = e.target.files[0];
+            if(!file) return;
+            const cards = await window.importApkgFile(file);
+            if(cards.length){
+                allFlashcards = allFlashcards.concat(cards);
+                const current = getQueryParam('specialty');
+                if(current && current === cards[0].specialty){
+                    flashcards = flashcards.concat(cards);
+                    showCard();
+                }
+                saveFlashcards();
+            }
+            importApkgInput.value = '';
+        });
     }
     if (prevBtn) prevBtn.addEventListener("click", showPreviousCard);
     if (themeToggle) themeToggle.addEventListener('click', toggleTheme);

--- a/flashcards.html
+++ b/flashcards.html
@@ -62,6 +62,9 @@
                 <button id="export-btn" class="small-btn">Exportar</button>
                 <button id="import-btn" class="small-btn">Importar</button>
                 <input type="file" id="import-input" accept="application/json" style="display:none">
+                <button id="export-apkg-btn" class="small-btn">Exportar mazo actual</button>
+                <button id="import-apkg-btn" class="small-btn">Importar .apkg</button>
+                <input type="file" id="import-apkg-input" accept=".apkg" style="display:none">
                 <a href="cloze.html" class="small-btn">Crear Cloze</a>
             </div>
         </main>
@@ -95,13 +98,19 @@
             <div class="form-group">
                 <select id="new-specialty" class="form-input"></select>
             </div>
-            <button id="add-card-btn" class="primary">Agregar Tarjeta</button>
-        </div>
+        <button id="add-card-btn" class="primary">Agregar Tarjeta</button>
     </div>
+    <div id="process-container" class="processing" role="status" aria-live="polite">
+        <div class="spinner" aria-hidden="true"></div>
+        <span id="progress-text">Procesando…</span>
+    </div>
+</div>
 
     <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
     <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/sql-wasm.js"></script>
     <script src="main.js"></script>
     <script src="app.js"></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -44,6 +44,8 @@
         </main>
     </div>
     <script src="js/chart.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/sql-wasm.js"></script>
     <script src="app.js"></script>
     <script>
         if ('serviceWorker' in navigator) {

--- a/main.js
+++ b/main.js
@@ -48,6 +48,157 @@
     container.append(...temp.childNodes);
   };
 
+  async function showProcess(text){
+    const box = document.getElementById('process-container');
+    if(box){
+      box.style.display = 'flex';
+      const t = box.querySelector('#progress-text');
+      if(t) t.textContent = text || 'Procesando…';
+    }
+  }
+
+  function hideProcess(){
+    const box = document.getElementById('process-container');
+    if(box){
+      box.style.display = 'none';
+    }
+  }
+
+  window.importApkgFile = async function(file){
+    const start = performance.now();
+    if(!file) return [];
+    if(file.size > 50 * 1024 * 1024){
+      alert('Paquete demasiado grande');
+      return [];
+    }
+    await showProcess('Procesando…');
+    try{
+      const buf = await file.arrayBuffer();
+      const zip = await JSZip.loadAsync(buf);
+      const col = zip.file('collection.anki2');
+      if(!col){ hideProcess(); alert('Paquete Anki inválido'); return []; }
+      const colData = await col.async('uint8array');
+      const SQL = await initSqlJs({ locateFile: f => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/${f}` });
+      const db = new SQL.Database(colData);
+      const notesRes = db.exec('SELECT id, flds FROM notes');
+      const cardsRes = db.exec('SELECT nid FROM cards');
+      const cardNids = new Set(cardsRes[0] ? cardsRes[0].values.map(v=>v[0]) : []);
+      const mediaMap = zip.file('media') ? JSON.parse(await zip.file('media').async('string')) : {};
+      const mediaBlobs = {};
+      for(const id in mediaMap){
+        const f = zip.file(id);
+        if(f && f._data.uncompressedSize <= 5*1024*1024){
+          mediaBlobs[id] = await f.async('blob');
+        }
+      }
+      const cards = [];
+      if(notesRes[0]){
+        for(const row of notesRes[0].values){
+          const nid = row[0];
+          if(!cardNids.has(nid)) continue;
+          const parts = String(row[1]).split('\u001f');
+          if(parts.length !== 2) continue;
+          let [front, back] = parts;
+          front = replaceMedia(front);
+          back = replaceMedia(back);
+          cards.push({
+            question: front,
+            answer: back,
+            specialty: `Importado-${file.name.replace(/\.apkg$/,'')}`,
+            difficulty: 'medium',
+            category: 'definicion',
+            lastReviewed: null,
+            nextReview: null,
+            reviewCount: 0
+          });
+          if(cards.length >= 10000) break;
+        }
+      }
+      hideProcess();
+      const secs = ((performance.now()-start)/1000).toFixed(1);
+      alert(`Se importaron ${cards.length} tarjetas en ${secs} s`);
+      return cards;
+
+      function replaceMedia(text){
+        return text.replace(/<img[^>]+src="(\d+)"[^>]*>/g, (m,id)=>{
+          const b = mediaBlobs[id];
+          if(!b) return m;
+          const url = URL.createObjectURL(b);
+          return m.replace(id, url);
+        }).replace(/\[sound:(\d+)\]/g,(m,id)=>{
+          const b = mediaBlobs[id];
+          if(!b) return '';
+          const url = URL.createObjectURL(b);
+          return `<audio src="${url}" controls></audio>`;
+        });
+      }
+    }catch(err){
+      hideProcess();
+      console.error(err);
+      alert('Paquete Anki inválido');
+      return [];
+    }
+  };
+
+  window.exportDeckToApkg = async function(deckName, cards){
+    if(!cards || !cards.length) return;
+    await showProcess('Procesando…');
+    try{
+      const SQL = await initSqlJs({ locateFile: f => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/${f}` });
+      const db = new SQL.Database();
+      const now = Math.floor(Date.now()/1000);
+      db.run('CREATE TABLE col(id integer primary key, crt integer, mod integer, scm integer, ver integer, dty integer, usn integer, ls integer, conf text, models text, decks text, dconf text, tags text);');
+      db.run('CREATE TABLE notes(id integer primary key, guid text, mid integer, mod integer, usn integer, tags text, flds text, sfld integer, csum integer, flags integer, data text);');
+      db.run('CREATE TABLE cards(id integer primary key, nid integer, did integer, ord integer, mod integer, usn integer, type integer, queue integer, due integer, ivl integer, factor integer, reps integer, lapses integer, left integer, odue integer, odid integer, flags integer, data text);');
+      db.run('CREATE TABLE revlog(id integer primary key, cid integer, usn integer, ease integer, ivl integer, lastIvl integer, factor integer, time integer, type integer);');
+      const decksObj = {"1":{id:1,name:deckName,mod:now,usn:0}};
+      const modelsObj = {"1":{id:1,name:'Basic',did:1,mod:now,usn:0,flds:[{name:'Front'},{name:'Back'}],tmpls:[{name:'Card 1',qfmt:'{{Front}}',afmt:'{{FrontSide}}<hr id=answer>{{Back}}'}]}};
+      db.run('INSERT INTO col VALUES (1,?,?,?,?,11,0,0,0,?,?,?,?);',[now,now,now,JSON.stringify({}),JSON.stringify(modelsObj),JSON.stringify(decksObj),JSON.stringify({}),JSON.stringify([])]);
+      let noteId=1, cardId=1;
+      const media = {};
+      const mediaFiles = {};
+      let mediaId = 0;
+      for(const c of cards){
+        const flds = `${c.question}\u001f${c.answer}`;
+        db.run("INSERT INTO notes VALUES (?,?,?,?,0,'',?, ?,0,0,'');", [noteId, `g${noteId}${now}`, 1, now, flds, c.question]);
+        db.run("INSERT INTO cards VALUES (?,?,?,?,0,0,0,0,?,?,0,0,0,0,0,0,0,'');", [cardId, noteId, 1, 0, now, now]);
+        for(const url of extractUrls(c.question+c.answer)){
+          try{
+            const resp = await fetch(url);
+            const blob = await resp.blob();
+            if(blob.size > 5*1024*1024) continue;
+            const ext = blob.type.split('/')[1]||'bin';
+            const name = `media${mediaId}.${ext}`;
+            media[mediaId] = name;
+            mediaFiles[`media/${name}`] = blob;
+            mediaId++;
+          }catch{}
+        }
+        noteId++; cardId++;
+      }
+      const dbData = db.export();
+      const zip = new JSZip();
+      zip.file('collection.anki2', dbData);
+      zip.file('media', JSON.stringify(media));
+      for(const k in mediaFiles){ zip.file(k, mediaFiles[k]); }
+      const blob = await zip.generateAsync({type:'blob'});
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = `${deckName}.apkg`;
+      a.click();
+      hideProcess();
+      alert('Exportación completada ✓');
+
+      function extractUrls(text){
+        const res=[]; const r=/src="(blob:[^"]+)"/g; let m; while((m=r.exec(text))) res.push(m[1]); return res;
+      }
+    }catch(err){
+      hideProcess();
+      console.error(err);
+      alert('Error al exportar');
+    }
+  };
+
   document.addEventListener('DOMContentLoaded', () => {
     const previewBtn = document.getElementById('preview-answer-btn');
     const previewArea = document.getElementById('answer-preview');

--- a/styles.css
+++ b/styles.css
@@ -496,3 +496,24 @@ body.dark-mode .level-3 { background-color: #4338ca; }
 body.dark-mode .md-audio {
     filter: invert(1) hue-rotate(180deg);
 }
+
+.processing {
+    display: none;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.processing .spinner {
+    width: 20px;
+    height: 20px;
+    border: 3px solid #ccc;
+    border-top-color: var(--primary-color);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- add JSZip and sql.js CDNs
- support importing/exporting `.apkg` decks in UI
- show progress spinner for heavy tasks
- expose helper functions in `main.js` for handling Anki packages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c7178b11883288ce1fa2f9a56de73