### PR TITLE
Implement deck hierarchy editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,10 +40,17 @@
             <div id="heatmap-metrics" class="heatmap-metrics"></div>
         </section>
 
+        <section class="deck-management">
+            <h2>Gestión de Mazos</h2>
+            <div id="deck-editor"></div>
+        </section>
+
         <main class="specialty-grid" id="specialty-grid">
         </main>
     </div>
     <script src="js/chart.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+    <script src="main.js"></script>
     <script src="app.js"></script>
     <script>
         if ('serviceWorker' in navigator) {

--- a/main.js
+++ b/main.js
@@ -302,3 +302,310 @@
     localStorage.setItem('exams', JSON.stringify(exams));
   }
 })();
+
+(function(){
+  const editor = document.getElementById('deck-editor');
+  if(!editor) return;
+
+  let hierarchy = [];
+
+  function genId(){
+    return 'n' + Date.now().toString(36) + Math.random().toString(36).slice(2);
+  }
+
+  function truncate(t){
+    return t.length > 100 ? t.slice(0,100) + '…' : t;
+  }
+
+  function loadHierarchy(){
+    try {
+      hierarchy = JSON.parse(localStorage.getItem('decksHierarchy')) || [];
+    } catch { hierarchy = []; }
+    if(!Array.isArray(hierarchy) || hierarchy.length === 0){
+      hierarchy = [{id: genId(), type:'deck', title:'Mazo', children:[]}];
+      saveHierarchy();
+    }
+  }
+
+  function saveHierarchy(){
+    localStorage.setItem('decksHierarchy', JSON.stringify(hierarchy));
+  }
+
+  function buildLi(node, level){
+    const li = document.createElement('li');
+    li.dataset.id = node.id;
+    li.dataset.type = node.type;
+    li.setAttribute('role','treeitem');
+    li.setAttribute('aria-level', level);
+
+    const row = document.createElement('div');
+    row.className = 'deck-row';
+
+    const arrow = document.createElement('span');
+    arrow.className = 'arrow';
+    arrow.textContent = node.children && node.children.length ? '\u25BE' : '';
+    arrow.addEventListener('click', () => toggle(li));
+
+    const icon = document.createElement('span');
+    icon.textContent = node.type==='deck'?'\uD83D\uDCC1':(node.type==='subdeck'?'\uD83D\uDCD2':'\uD83D\uDCC4');
+
+    const title = document.createElement('span');
+    title.className = 'node-title';
+    title.textContent = truncate(node.title);
+    title.dataset.full = node.title;
+    title.tabIndex = 0;
+    title.addEventListener('dblclick', () => startEdit(title,node));
+    title.addEventListener('keydown', e => { if(e.key==='Enter') startEdit(title,node); });
+
+    const input = document.createElement('input');
+    input.className = 'edit-input';
+    input.value = node.title;
+    input.style.display = 'none';
+    input.addEventListener('blur', () => finishEdit(title,input,node));
+    input.addEventListener('keydown', e => {
+      if(e.key==='Enter') input.blur();
+      if(e.key==='Escape'){ input.value=node.title; input.blur(); }
+    });
+
+    row.append(arrow, icon, title, input);
+
+    if(node.type !== 'card'){
+      const addSub = document.createElement('button');
+      addSub.className = 'icon-btn';
+      addSub.textContent = '+';
+      addSub.setAttribute('aria-label','Añadir submazo');
+      addSub.addEventListener('click', () => addSubdeck(node));
+      row.appendChild(addSub);
+
+      const addCardBtn = document.createElement('button');
+      addCardBtn.className = 'icon-btn';
+      addCardBtn.textContent = '+T';
+      addCardBtn.setAttribute('aria-label','Añadir tarjeta');
+      addCardBtn.addEventListener('click', () => addCard(node));
+      row.appendChild(addCardBtn);
+    }
+
+    const del = document.createElement('button');
+    del.className = 'icon-btn';
+    del.textContent = '\u2716';
+    del.setAttribute('aria-label','Eliminar');
+    del.addEventListener('click', () => deleteNode(node.id));
+    row.appendChild(del);
+
+    li.appendChild(row);
+
+    const ul = document.createElement('ul');
+    if(node.children && node.children.length){
+      node.children.forEach(c => ul.appendChild(buildLi(c, level+1)));
+    } else {
+      ul.style.display = 'none';
+    }
+    li.appendChild(ul);
+    return li;
+  }
+
+  function toggle(li){
+    const ul = li.querySelector('ul');
+    if(!ul) return;
+    const arrow = li.querySelector('.arrow');
+    const show = ul.style.display === 'none';
+    ul.style.display = show ? 'block' : 'none';
+    arrow.textContent = show ? '\u25BE' : '\u25B8';
+  }
+
+  function addSubdeck(parent){
+    parent.children.push({id:genId(), type:'subdeck', title:'Submazo', children:[]});
+    saveHierarchy();
+    render();
+  }
+
+  function addCard(parent){
+    parent.children.push({id:genId(), type:'card', title:'Tarjeta', children:[]});
+    saveHierarchy();
+    render();
+  }
+
+  function deleteNode(id){
+    if(!confirm(`Eliminar '${findTitle(id)}' y todo su contenido?`)) return;
+    removeById(hierarchy, id);
+    saveHierarchy();
+    render();
+  }
+
+  function findTitle(id,list=hierarchy){
+    for(const n of list){
+      if(n.id===id) return n.title;
+      const t = findTitle(id,n.children||[]);
+      if(t) return t;
+    }
+    return '';
+  }
+
+  function removeById(list, id){
+    const idx = list.findIndex(n => n.id===id);
+    if(idx>-1){ list.splice(idx,1); return true; }
+    for(const n of list){
+      if(n.children && removeById(n.children,id)) return true;
+    }
+    return false;
+  }
+
+  function startEdit(span,node){
+    const input = span.nextElementSibling;
+    span.style.display = 'none';
+    input.style.display = 'inline-block';
+    input.value = node.title;
+    input.focus();
+  }
+
+  function finishEdit(span,input,node){
+    let val = input.value.trim();
+    if(!val){
+      alert('El título no puede quedar vacío');
+      input.focus();
+      return;
+    }
+    if(val.length>100) val = val.slice(0,100);
+    node.title = val;
+    span.dataset.full = val;
+    span.textContent = truncate(val);
+    span.style.display = '';
+    input.style.display = 'none';
+    saveHierarchy();
+  }
+
+  function expandCollapseAll(exp){
+    editor.querySelectorAll('ul').forEach(ul => {
+      ul.style.display = exp?'block':'none';
+    });
+    editor.querySelectorAll('.arrow').forEach(a => {
+      a.textContent = exp ? '\u25BE' : '\u25B8';
+    });
+  }
+
+  function parseUl(ul){
+    return Array.from(ul.children).map(li => ({
+      id: li.dataset.id,
+      type: li.dataset.type,
+      title: li.querySelector('.node-title').dataset.full,
+      children: parseUl(li.querySelector('ul')||document.createElement('ul'))
+    }));
+  }
+
+  function updateFromDom(){
+    const root = editor.querySelector('.tree-root');
+    if(root) hierarchy = parseUl(root);
+    saveHierarchy();
+  }
+
+  function initSortables(root){
+    if(typeof Sortable==='undefined') return;
+    root.querySelectorAll('ul').forEach(ul => {
+      if(ul.parentElement && ul.parentElement.dataset.type==='card') return;
+      Sortable.create(ul, {
+        group: 'nested',
+        animation: 150,
+        fallbackOnBody: true,
+        onStart: e => e.item.classList.add('dragging'),
+        onEnd: e => { e.item.classList.remove('dragging'); updateFromDom(); },
+        onMove: evt => {
+          const destLi = evt.to.closest('li');
+          if(destLi && destLi.dataset.type==='card') return false;
+          if(evt.dragged.contains(destLi)) return false;
+        }
+      });
+    });
+  }
+
+  function render(){
+    editor.innerHTML = '';
+
+    if(typeof Sortable==='undefined'){
+      const banner = document.createElement('div');
+      banner.className = 'banner error';
+      banner.textContent = 'Arrastrar-y-soltar no disponible, revisa tu conexión';
+      editor.appendChild(banner);
+    }
+
+    const controls = document.createElement('div');
+    const newBtn = document.createElement('button');
+    newBtn.textContent = 'Nuevo Mazo';
+    newBtn.className = 'small-btn';
+    const expBtn = document.createElement('button');
+    expBtn.textContent = 'Expandir todo';
+    expBtn.className = 'small-btn';
+    const colBtn = document.createElement('button');
+    colBtn.textContent = 'Contraer todo';
+    colBtn.className = 'small-btn';
+    controls.append(newBtn, expBtn, colBtn);
+    editor.appendChild(controls);
+
+    const tree = document.createElement('ul');
+    tree.className = 'tree-root';
+    hierarchy.forEach(n => tree.appendChild(buildLi(n,1)));
+    editor.appendChild(tree);
+
+    newBtn.addEventListener('click', () => {
+      hierarchy.push({id:genId(), type:'deck', title:'Mazo', children:[]});
+      saveHierarchy();
+      render();
+    });
+    expBtn.addEventListener('click', () => expandCollapseAll(true));
+    colBtn.addEventListener('click', () => expandCollapseAll(false));
+
+    initSortables(editor);
+  }
+
+  function handleKeys(e){
+    const t = document.activeElement;
+    if(!t.classList.contains('node-title')) return;
+    const li = t.closest('li');
+    if(e.key==='ArrowDown'){
+      const n = li.nextElementSibling;
+      if(n) n.querySelector('.node-title').focus();
+      e.preventDefault();
+    } else if(e.key==='ArrowUp'){
+      const p = li.previousElementSibling;
+      if(p) p.querySelector('.node-title').focus();
+      e.preventDefault();
+    } else if(e.key==='ArrowRight'){
+      const ul = li.querySelector('ul');
+      if(ul && ul.style.display==='none'){
+        toggle(li);
+      } else if(ul){
+        const c = ul.querySelector('.node-title');
+        if(c) c.focus();
+      }
+      e.preventDefault();
+    } else if(e.key==='ArrowLeft'){
+      const ul = li.querySelector('ul');
+      if(ul && ul.style.display!=='none'){
+        toggle(li);
+      } else {
+        const parent = li.parentElement.closest('li');
+        if(parent) parent.querySelector('.node-title').focus();
+      }
+      e.preventDefault();
+    } else if(e.key==='Enter'){
+      startEdit(t, findNode(li.dataset.id));
+      e.preventDefault();
+    }
+  }
+
+  function findNode(id,list=hierarchy){
+    for(const n of list){
+      if(n.id===id) return n;
+      const r = findNode(id,n.children||[]);
+      if(r) return r;
+    }
+    return null;
+  }
+
+  function init(){
+    loadHierarchy();
+    render();
+    editor.addEventListener('keydown', handleKeys);
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/styles.css
+++ b/styles.css
@@ -505,3 +505,68 @@ body.dark-mode .md-audio {
 #time-bar-fill { height:100%; background:var(--primary-color); width:100%; transition:width 1s linear; }
 #time-remaining { min-width:50px; font-weight:700; color:var(--danger-color); }
 .exam-q-text { margin:20px 0; min-height:80px; }
+
+/* Deck editor */
+.deck-management {
+    margin-bottom: 30px;
+}
+
+#deck-editor ul {
+    list-style: none;
+    padding-left: 0;
+}
+
+#deck-editor ul ul {
+    margin-left: 10px;
+}
+
+#deck-editor li {
+    margin: 2px 0;
+}
+
+#deck-editor .deck-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: grab;
+}
+
+#deck-editor .dragging .deck-row {
+    cursor: grabbing;
+}
+
+#deck-editor .icon-btn {
+    width: 20px;
+    height: 20px;
+    border: none;
+    border-radius: 4px;
+    background: var(--secondary-color);
+    color: #fff;
+    font-size: 0.7rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+#deck-editor .icon-btn:hover {
+    background: var(--primary-color);
+}
+
+#deck-editor .arrow {
+    user-select: none;
+    cursor: pointer;
+}
+
+.banner {
+    padding: 10px;
+    border-radius: 4px;
+    margin-bottom: 10px;
+    background: var(--warning-color);
+    color: #212529;
+}
+
+.banner.error {
+    background: var(--danger-color);
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- add deck management section with editor container
- load SortableJS and main.js on home page
- implement deck editor logic with nested drag-and-drop in `main.js`
- style deck editor elements

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c73142d748328bbea945f8c57e0b3