### PR TITLE
Add try-catch for flashcard parsing

### DIFF
--- a/app.js
+++ b/app.js
@@ -512,8 +512,14 @@ function initHomePage() {
 function loadFlashcards() {
     const savedFlashcards = localStorage.getItem('medicalFlashcards');
     if (savedFlashcards) {
-        allFlashcards = JSON.parse(savedFlashcards);
-        flashcards = allFlashcards;
+        try {
+            allFlashcards = JSON.parse(savedFlashcards);
+            flashcards = allFlashcards;
+        } catch (e) {
+            localStorage.removeItem('medicalFlashcards');
+            alert('Error al cargar las tarjetas guardadas. Se reinició el almacenamiento.');
+            allFlashcards = flashcards;
+        }
     } else {
         allFlashcards = flashcards;
     }


### PR DESCRIPTION
## Summary
- handle JSON.parse errors when loading flashcards

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c7a476bb08328b30020df2d4df363