### PR TITLE
Add beforeunload handler in exam init

### DIFF
--- a/main.js
+++ b/main.js
@@ -182,6 +182,7 @@
       });
       next.addEventListener('click', () => submitAnswer());
     }
+    window.addEventListener('beforeunload', () => clearInterval(examState.timer));
   }
 
   window.startAdaptiveExam = function(){


### PR DESCRIPTION
## Summary
- clear the exam timer when the page unloads so intervals do not linger

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8d4e558483288c6eca31c151fa85