### PR TITLE
Remove leftover keydown handlers

### DIFF
--- a/app.js
+++ b/app.js
@@ -777,7 +777,8 @@ function importFlashcards(e) {
 }
 
 // Handle keyboard navigation
-function handleKeyDown(e) {
+// Keep a reference to remove this listener later
+const handleKeyDown = (e) => {
     switch(e.key) {
         case 'ArrowLeft':
             showPreviousCard();
@@ -801,6 +802,11 @@ function handleKeyDown(e) {
             break;
     }
 }
+
+// Remove keyboard listener when leaving the page
+window.addEventListener('beforeunload', () => {
+    document.removeEventListener('keydown', handleKeyDown);
+});
 
 // Initialize the application when the DOM is fully loaded
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- keep reference for keyboard navigation handler
- remove keydown listener on beforeunload to avoid duplicates

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8d503e588328bf84a27bdbb1f3a5