### PR TITLE
Improve deck hierarchy buttons

### DIFF
--- a/main.js
+++ b/main.js
@@ -342,10 +342,18 @@
     const row = document.createElement('div');
     row.className = 'deck-row';
 
-    const arrow = document.createElement('span');
+    const arrow = document.createElement('button');
     arrow.className = 'arrow';
+    arrow.setAttribute('type', 'button');
+    arrow.setAttribute('aria-label', 'Expandir o contraer');
     arrow.textContent = node.children && node.children.length ? '\u25BE' : '';
     arrow.addEventListener('click', () => toggle(li));
+    arrow.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+        e.preventDefault();
+        toggle(li);
+      }
+    });
 
     const icon = document.createElement('span');
     icon.textContent = node.type==='deck'?'\uD83D\uDCC1':(node.type==='subdeck'?'\uD83D\uDCD2':'\uD83D\uDCC4');

--- a/styles.css
+++ b/styles.css
@@ -573,6 +573,10 @@ body.dark-mode .md-audio {
 #deck-editor .arrow {
     user-select: none;
     cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
 }
 
 .banner {


### PR DESCRIPTION
## Summary
- convert deck expansion arrow from `<span>` to `<button>` so it can be activated via keyboard
- preserve previous look for the button
- handle Enter/Space key presses explicitly

## Testing
- `npm test --silent` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c90417b4483288fb33931f3f860e7