### PR TITLE
Improve heatmap UX

### DIFF
--- a/app.js
+++ b/app.js
@@ -303,12 +303,13 @@ function renderWeakTopics() {
 }
 
 // ---- Study Heatmap ----
-function logReviewResult(difficulty) {
+function logReviewResult(difficulty, question) {
     const todayKey = new Date().toISOString().slice(0, 10);
     const history = JSON.parse(localStorage.getItem('studyHistory') || '{}');
-    const entry = history[todayKey] || { reviews: 0, correct: 0 };
+    const entry = history[todayKey] || { reviews: 0, correct: 0, cards: [] };
     entry.reviews++;
     if (difficulty !== 'hard') entry.correct++;
+    if (question) entry.cards.push(question);
     history[todayKey] = entry;
     localStorage.setItem('studyHistory', JSON.stringify(history));
 }
@@ -327,17 +328,18 @@ function getStudyData() {
         const rec = history[key];
         if (rec) {
             const accuracy = rec.reviews ? Math.round((rec.correct / rec.reviews) * 100) : 0;
-            data.push({ date: key, reviews: rec.reviews, accuracy });
+            data.push({ date: key, reviews: rec.reviews, accuracy, cards: rec.cards || [] });
         } else {
-            data.push({ date: key, reviews: 0 });
+            data.push({ date: key, reviews: 0, cards: [] });
         }
     }
     return data;
 }
 
 function getLevelClass(rev) {
-    if (rev >= 11) return 'level-3';
-    if (rev >= 6) return 'level-2';
+    if (rev >= 11) return 'level-4';
+    if (rev >= 6) return 'level-3';
+    if (rev >= 3) return 'level-2';
     if (rev >= 1) return 'level-1';
     return 'level-0';
 }
@@ -345,9 +347,11 @@ function getLevelClass(rev) {
 function renderStudyHeatmap(data) {
     const container = document.getElementById('study-heatmap');
     const metrics = document.getElementById('heatmap-metrics');
+    const legend = document.getElementById('heatmap-legend');
     if (!container || !metrics) return;
     container.innerHTML = '';
     metrics.innerHTML = '';
+    if (legend) legend.innerHTML = '';
 
     const monthsDiv = document.createElement('div');
     monthsDiv.className = 'months';
@@ -371,9 +375,10 @@ function renderStudyHeatmap(data) {
         const cell = document.createElement('div');
         cell.className = 'heatmap-cell ' + getLevelClass(item.reviews);
         cell.tabIndex = 0;
-        const localDate = date.toLocaleDateString();
-        const accText = item.accuracy !== undefined ? ` \u00B7 ${item.accuracy}% de aciertos` : '';
-        cell.title = `${item.reviews} repasos el ${localDate}${accText}`;
+        const accText = item.accuracy !== undefined ? ` \u2022 ${item.accuracy}% aciertos` : '';
+        cell.title = item.reviews > 0
+            ? `${item.reviews} repasos${accText}`
+            : 'Sin repasos';
         cell.style.gridRow = (date.getDay() + 1);
         cell.style.gridColumn = (week + 1);
         cell.addEventListener('click', () => openDayModal(item.date));
@@ -408,10 +413,37 @@ function renderStudyHeatmap(data) {
         `<div>Racha hist\xF3rica: ${longest} d\xEDas</div>` +
         `<div>Total de repasos: ${total}</div>` +
         `<div>Exactitud promedio: ${avgAcc}%</div>`;
+
+    if (legend) {
+        legend.innerHTML = `0 <div class="box level-1"></div><div class="box level-2"></div><div class="box level-3"></div><div class="box level-4"></div> 11+`;
+    }
 }
 
 function openDayModal(date) {
-    alert(`Tarjetas repasadas el ${new Date(date).toLocaleDateString()}`);
+    const history = JSON.parse(localStorage.getItem('studyHistory') || '{}');
+    const entry = history[date];
+    const modal = document.getElementById('day-modal');
+    const title = document.getElementById('modal-title');
+    const list = document.getElementById('modal-list');
+    if (!modal || !title || !list || !entry) return;
+    title.textContent = new Date(date).toLocaleDateString();
+    list.innerHTML = '';
+    (entry.cards || []).forEach(q => {
+        const li = document.createElement('li');
+        li.textContent = q;
+        list.appendChild(li);
+    });
+    if (list.children.length === 0) {
+        const li = document.createElement('li');
+        li.textContent = 'Sin tarjetas';
+        list.appendChild(li);
+    }
+    modal.setAttribute('aria-hidden', 'false');
+}
+
+function closeDayModal() {
+    const modal = document.getElementById('day-modal');
+    if (modal) modal.setAttribute('aria-hidden', 'true');
 }
 
 function populateSpecialtySelect() {
@@ -494,6 +526,14 @@ function initHomePage() {
     renderProgressChart();
     renderWeakTopics();
     renderStudyHeatmap(getStudyData());
+    const closeModalBtn = document.getElementById('close-day-modal');
+    const dayModal = document.getElementById('day-modal');
+    if (closeModalBtn && dayModal) {
+        closeModalBtn.addEventListener('click', () => dayModal.setAttribute('aria-hidden', 'true'));
+        dayModal.addEventListener('click', e => {
+            if (e.target === dayModal) dayModal.setAttribute('aria-hidden', 'true');
+        });
+    }
     if (changePicBtn && profilePicInput) {
         changePicBtn.addEventListener('click', () => profilePicInput.click());
         profilePicInput.addEventListener('change', handleProfilePicChange);
@@ -639,7 +679,7 @@ function setDifficulty(difficulty) {
     const currentCard = flashcards[currentCardIndex];
     const now = new Date();
 
-    logReviewResult(difficulty);
+    logReviewResult(difficulty, currentCard.question);
 
     // Update card data
     currentCard.difficulty = difficulty;

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
         <section class="heatmap-panel">
             <div id="study-heatmap" class="study-heatmap"></div>
             <div id="heatmap-metrics" class="heatmap-metrics"></div>
+            <div id="heatmap-legend" class="heatmap-legend"></div>
         </section>
 
         <section class="deck-management">
@@ -59,5 +60,12 @@
             navigator.serviceWorker.register('sw.js');
         }
     </script>
+    <div id="day-modal" class="modal" aria-hidden="true">
+        <div class="modal-content">
+            <button id="close-day-modal" class="close-btn" aria-label="Cerrar">&times;</button>
+            <h3 id="modal-title"></h3>
+            <ul id="modal-list"></ul>
+        </div>
+    </div>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -455,21 +455,37 @@ h1 {
     outline-offset: 1px;
 }
 
+
 .level-0 { background-color: #e6f4ea; }
-.level-1 { background-color: #b7e4c7; }
-.level-2 { background-color: #52b788; }
-.level-3 { background-color: #2d6a4f; }
+.level-1 { background-color: #c7e9c0; }
+.level-2 { background-color: #94d7a2; }
+.level-3 { background-color: #52b788; }
+.level-4 { background-color: #2d6a4f; }
 
 body.dark-mode .level-0 { background-color: #e0e7ff; }
-body.dark-mode .level-1 { background-color: #a5b4fc; }
-body.dark-mode .level-2 { background-color: #6366f1; }
-body.dark-mode .level-3 { background-color: #4338ca; }
+body.dark-mode .level-1 { background-color: #c7d2fe; }
+body.dark-mode .level-2 { background-color: #a5b4fc; }
+body.dark-mode .level-3 { background-color: #6366f1; }
+body.dark-mode .level-4 { background-color: #4338ca; }
 
 .heatmap-metrics {
     display: flex;
     flex-direction: column;
     font-size: 0.9rem;
     gap: 4px;
+}
+
+.heatmap-legend {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.7rem;
+}
+
+.heatmap-legend .box {
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
 }
 
 /* Cloze card creator */
@@ -590,4 +606,40 @@ body.dark-mode .md-audio {
 .banner.error {
     background: var(--danger-color);
     color: #fff;
+}
+
+/* Modal */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal[aria-hidden="false"] {
+    display: flex;
+}
+
+.modal-content {
+    background: var(--card-background);
+    padding: 20px;
+    border-radius: var(--border-radius);
+    max-width: 300px;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: var(--box-shadow);
+}
+
+.close-btn {
+    background: none;
+    border: none;
+    font-size: 1.2rem;
+    float: right;
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- implement modal for heatmap days
- track reviewed cards for each day
- add color legend and extend green gradient
- show tooltip with accuracy

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c9a150bb083288898c0ec7c62c6c7