### PR TITLE
Improve home page metrics and CTA

### DIFF
--- a/app.js
+++ b/app.js
@@ -403,11 +403,22 @@ function renderStudyHeatmap(data) {
     }
 
     const avgAcc = accCount ? (accSum / accCount).toFixed(1) : 'N/A';
-    metrics.innerHTML =
-        `<div>Racha actual: ${current} d\xEDas</div>` +
-        `<div>Racha hist\xF3rica: ${longest} d\xEDas</div>` +
-        `<div>Total de repasos: ${total}</div>` +
-        `<div>Exactitud promedio: ${avgAcc}%</div>`;
+
+    const dataMetrics = [
+        { icon: '🔥', value: current, label: 'Racha' },
+        { icon: '📚', value: total, label: 'Total' },
+        { icon: '🎯', value: `${avgAcc}%`, label: 'Exactitud' }
+    ];
+
+    dataMetrics.forEach(m => {
+        const card = document.createElement('div');
+        card.className = 'metric-card';
+        card.innerHTML =
+            `<span class="metric-icon">${m.icon}</span>` +
+            `<span class="metric-number">${m.value}</span>` +
+            `<span class="metric-label">${m.label}</span>`;
+        metrics.appendChild(card);
+    });
 }
 
 function openDayModal(date) {

--- a/index.html
+++ b/index.html
@@ -39,7 +39,11 @@
 
         <section class="heatmap-panel">
             <div id="study-heatmap" class="study-heatmap"></div>
-            <div id="heatmap-metrics" class="heatmap-metrics"></div>
+            <div id="heatmap-metrics" class="heatmap-metrics metrics"></div>
+        </section>
+
+        <section class="cta-section">
+            <a href="flashcards.html" id="continue-btn" class="cta-primary">Seguir estudiando</a>
         </section>
 
         <section class="deck-management">

--- a/styles.css
+++ b/styles.css
@@ -467,9 +467,56 @@ body.dark-mode .level-3 { background-color: #4338ca; }
 
 .heatmap-metrics {
     display: flex;
-    flex-direction: column;
-    font-size: 0.9rem;
-    gap: 4px;
+    gap: 10px;
+    justify-content: center;
+    margin-top: 10px;
+}
+
+.metric-card {
+    background: var(--card-background);
+    box-shadow: var(--box-shadow);
+    border-radius: var(--border-radius);
+    padding: 10px;
+    text-align: center;
+    flex: 1;
+    min-width: 80px;
+}
+
+.metric-icon {
+    font-size: 1.2rem;
+    display: block;
+}
+
+.metric-number {
+    display: block;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.metric-label {
+    font-size: 0.8rem;
+    color: var(--secondary-color);
+}
+
+.cta-primary {
+    display: inline-block;
+    padding: 12px 20px;
+    background-color: var(--primary-color);
+    color: #fff;
+    text-decoration: none;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    font-size: 1.1rem;
+}
+
+.cta-primary:hover {
+    background-color: #3a5a80;
+}
+
+.cta-section {
+    text-align: center;
+    margin: 20px 0;
 }
 
 /* Cloze card creator */


### PR DESCRIPTION
## Summary
- show heatmap metrics as cards with icons
- add prominent CTA button on home page
- style metric cards and CTA button

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c9982ae6c83288c946871634d2b92