### PR TITLE
Add deck carousel

### DIFF
--- a/app.js
+++ b/app.js
@@ -497,6 +497,63 @@ function renderSpecialtyCards() {
     });
 }
 
+function renderDeckCarousel() {
+    const container = document.getElementById('deck-carousel');
+    if (!container) return;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const stats = {};
+    specialties.forEach(s => {
+        stats[s.slug] = { pending: 0, newHard: 0 };
+    });
+
+    allFlashcards.forEach(card => {
+        const st = stats[card.specialty];
+        if (!st) return;
+        if (!card.lastReviewed || card.difficulty === 'hard') {
+            st.newHard++;
+        }
+        if (card.nextReview && new Date(card.nextReview) <= today) {
+            st.pending++;
+        }
+    });
+
+    container.innerHTML = '';
+    specialties.forEach(s => {
+        const card = document.createElement('div');
+        card.className = 'deck-card';
+
+        const icon = document.createElement('span');
+        icon.className = 'deck-icon';
+        icon.textContent = s.emoji;
+        if (stats[s.slug].pending > 0) {
+            icon.classList.add('pending');
+        }
+
+        const title = document.createElement('span');
+        title.className = 'deck-title';
+        title.textContent = s.name;
+
+        const badge = document.createElement('span');
+        badge.className = 'deck-badge';
+        const count = stats[s.slug].newHard;
+        if (count > 0) {
+            badge.textContent = count;
+        } else {
+            badge.style.display = 'none';
+        }
+
+        card.appendChild(icon);
+        card.appendChild(title);
+        card.appendChild(badge);
+        card.addEventListener('click', () => {
+            window.location.href = `flashcards.html?specialty=${s.slug}`;
+        });
+        container.appendChild(card);
+    });
+}
+
 // Initialize flashcards page
 function initFlashcardsPage() {
     populateSpecialtySelect();
@@ -538,6 +595,7 @@ function initFlashcardsPage() {
 function initHomePage() {
     loadTheme();
     renderSpecialtyCards();
+    renderDeckCarousel();
     loadProfilePic();
     loadUserName();
     renderProgressChart();

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
         <section class="deck-management">
             <h2>Gestión de Mazos</h2>
-            <div id="deck-editor"></div>
+            <div id="deck-carousel" class="deck-carousel"></div>
         </section>
 
         <main class="specialty-grid" id="specialty-grid">

--- a/styles.css
+++ b/styles.css
@@ -563,56 +563,52 @@ body.dark-mode .md-audio {
     margin-bottom: 30px;
 }
 
-#deck-editor ul {
-    list-style: none;
-    padding-left: 0;
-}
-
-#deck-editor ul ul {
-    margin-left: 10px;
-}
-
-#deck-editor li {
-    margin: 2px 0;
-}
-
-#deck-editor .deck-row {
+.deck-carousel {
     display: flex;
-    align-items: center;
-    gap: 4px;
-    cursor: grab;
+    overflow-x: auto;
+    gap: 10px;
+    padding-bottom: 10px;
+    scroll-behavior: smooth;
 }
 
-#deck-editor .dragging .deck-row {
-    cursor: grabbing;
+.deck-card {
+    position: relative;
+    flex: 0 0 auto;
+    min-width: 120px;
+    text-align: center;
+    background: var(--card-background);
+    padding: 15px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    cursor: pointer;
+    transition: transform 0.2s;
 }
 
-#deck-editor .icon-btn {
-    width: 20px;
-    height: 20px;
-    border: none;
-    border-radius: 4px;
-    background: var(--secondary-color);
+.deck-card:hover {
+    transform: translateY(-4px);
+}
+
+.deck-icon {
+    font-size: 2rem;
+    display: block;
+    margin-bottom: 5px;
+}
+
+.deck-icon.pending {
+    color: var(--danger-color);
+}
+
+.deck-badge {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: var(--warning-color);
     color: #fff;
-    font-size: 0.7rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: 12px;
+    font-size: 0.75rem;
 }
 
-#deck-editor .icon-btn:hover {
-    background: var(--primary-color);
-}
-
-#deck-editor .arrow {
-    user-select: none;
-    cursor: pointer;
-    background: none;
-    border: none;
-    padding: 0;
-    font: inherit;
-}
 
 .banner {
     padding: 10px;


### PR DESCRIPTION
## Summary
- create a horizontal deck carousel on the home screen
- display pending status and new/difficult counts per deck
- style carousel elements

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c9d7312348328b81f91eecb4f7fe6