### PR TITLE
Improve home screen interaction

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -323,12 +323,13 @@ h1 {
     background: var(--card-background);
     padding: 20px;
     border-radius: var(--border-radius);
-    box-shadow: var(--box-shadow);
-    transition: transform 0.2s;
+    box-shadow: none;
+    transition: transform 0.3s cubic-bezier(.34,1.56,.64,1), box-shadow 0.2s;
 }
 
 .specialty-card:hover {
-    transform: translateY(-4px);
+    transform: scale(1.05);
+    box-shadow: var(--box-shadow);
 }
 
 .specialty-card .emoji {


### PR DESCRIPTION
## Summary
- lighten card shadows when not hovering
- add subtle scale animation on hover for cards

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c9e3b202c8328b45dad32a0a1ad5c