### PR TITLE
Fix offline support for exam page

### DIFF
--- a/exam.html
+++ b/exam.html
@@ -39,5 +39,10 @@
         </div>
     </div>
     <script src="main.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('sw.js');
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- register service worker on `exam.html` so that it works offline like other pages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca583ebd083288a686374ffeed599