### PR TITLE
Cache CDN libs in service worker

### DIFF
--- a/flashcards.html
+++ b/flashcards.html
@@ -105,9 +105,9 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js" crossorigin="anonymous"></script>
     <script src="main.js"></script>
     <script src="app.js"></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         </main>
     </div>
     <script src="js/chart.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js" crossorigin="anonymous"></script>
     <script src="main.js"></script>
     <script src="app.js"></script>
     <script>

--- a/sw.js
+++ b/sw.js
@@ -9,7 +9,11 @@ const ASSETS = [
   'app.js',
   'cloze.js',
   'main.js',
-  'js/chart.min.js'
+  'js/chart.min.js',
+  'https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js',
+  'https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js',
+  'https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css',
+  'https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js'
 ];
 self.addEventListener('install', e => {
   e.waitUntil(caches.open(CACHE_NAME).then(c => c.addAll(ASSETS)));


### PR DESCRIPTION
## Summary
- allow CDN assets to be cached offline
- include cross origin attributes for CDN scripts and styles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca7a63b5c83289c023dee67a7941f