### PR TITLE
Add basic sliding menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
 </head>
 <body>
     <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">🌙</button>
+    <button id="menu-btn" class="menu-btn" aria-label="Abrir menú">
+        <span></span>
+        <span></span>
+        <span></span>
+    </button>
     <div class="container home">
         <header>
             <h1>Selecciona una Especialidad</h1>
@@ -57,6 +62,13 @@
             navigator.serviceWorker.register('sw.js');
         }
     </script>
+    <nav id="side-panel" class="side-panel" role="navigation" aria-hidden="true">
+        <h2>Menú</h2>
+        <ul>
+            <li><a href="index.html">Inicio</a></li>
+        </ul>
+    </nav>
+    <div id="side-overlay" class="side-overlay"></div>
     <div id="day-modal" class="modal" aria-hidden="true">
         <div class="modal-content">
             <button id="close-day-modal" class="close-btn" aria-label="Cerrar">&times;</button>

--- a/main.js
+++ b/main.js
@@ -87,6 +87,37 @@
     }
 
     initAdaptiveExam();
+
+    const menuBtn = document.getElementById('menu-btn');
+    const sidePanel = document.getElementById('side-panel');
+    const overlay = document.getElementById('side-overlay');
+
+    function toggleMenu(forceClose) {
+      if (!sidePanel || !overlay || !menuBtn) return;
+      const open = forceClose ? false : !sidePanel.classList.contains('open');
+      if (open) {
+        sidePanel.classList.add('open');
+        overlay.classList.add('open');
+        menuBtn.setAttribute('aria-label', 'Cerrar menú');
+        const firstLink = sidePanel.querySelector('a');
+        if (firstLink) firstLink.focus();
+      } else {
+        sidePanel.classList.remove('open');
+        overlay.classList.remove('open');
+        menuBtn.setAttribute('aria-label', 'Abrir menú');
+        menuBtn.focus();
+      }
+    }
+
+    if(menuBtn && overlay){
+      menuBtn.addEventListener('click', () => toggleMenu());
+      overlay.addEventListener('click', () => toggleMenu(true));
+      document.addEventListener('keydown', e => {
+        if(e.key === 'Escape' && sidePanel.classList.contains('open')){
+          toggleMenu(true);
+        }
+      });
+    }
   });
 
   // ----- Adaptive exam mode -----

--- a/styles.css
+++ b/styles.css
@@ -629,3 +629,59 @@ body.dark-mode .md-audio {
     float: right;
     cursor: pointer;
 }
+
+/* ----- Sliding menu ----- */
+.menu-btn {
+    position: fixed;
+    top: 40px;
+    left: 20px;
+    width: 30px;
+    height: 24px;
+    background: none;
+    border: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    z-index: 1100;
+    cursor: pointer;
+}
+
+.menu-btn span {
+    display: block;
+    height: 3px;
+    width: 100%;
+    background: var(--text-color);
+}
+
+.side-panel {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 250px;
+    height: 100%;
+    background: var(--card-background);
+    color: var(--text-color);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    padding: 20px;
+    z-index: 1000;
+}
+
+.side-panel.open {
+    transform: translateX(0);
+}
+
+.side-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    z-index: 900;
+}
+
+.side-overlay.open {
+    display: block;
+}


### PR DESCRIPTION
## Summary
- add hamburger button with fixed positioning
- implement sliding side menu and overlay styles
- support opening/closing menu via JS with focus management

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d2e8adc7c832896e6e73291d38236