### PR TITLE
Add topic detail view

### DIFF
--- a/app.js
+++ b/app.js
@@ -126,6 +126,19 @@ const specialtyNames = specialties.reduce((acc, s) => {
     return acc;
 }, {});
 
+let topics = JSON.parse(localStorage.getItem('studyTopics') || '[]');
+if (topics.length === 0) {
+    topics = [
+        { id: 'neonatologia', name: 'Neonatología', specialty: 'pediatria', total: 10, reviews: 0, errors: 0, mastery: 0 },
+        { id: 'infectologia', name: 'Infectología', specialty: 'pediatria', total: 8, reviews: 0, errors: 0, mastery: 0 },
+        { id: 'trauma', name: 'Trauma', specialty: 'cirugia', total: 12, reviews: 0, errors: 0, mastery: 0 }
+    ];
+}
+
+function saveTopics() {
+    localStorage.setItem('studyTopics', JSON.stringify(topics));
+}
+
 // DOM Elements
 const flashcard = document.getElementById('flashcard');
 const questionElement = document.getElementById('question');
@@ -158,6 +171,19 @@ const changeNameBtn = document.getElementById('change-name-btn');
 const userNameInput = document.getElementById('user-name-input');
 const progressChartCanvas = document.getElementById('progress-chart');
 const weakTopicsList = document.getElementById('weak-topics-list');
+const homeContainer = document.querySelector('.container.home');
+const topicView = document.getElementById('topic-view');
+const topicListEl = document.getElementById('topic-list');
+const topicViewTitle = document.getElementById('topic-view-title');
+const topicDetail = document.getElementById('topic-detail');
+const topicDetailTitle = document.getElementById('topic-detail-title');
+const metricTotal = document.getElementById('metric-total');
+const metricReviews = document.getElementById('metric-reviews');
+const metricErrors = document.getElementById('metric-errors');
+const metricMastery = document.getElementById('metric-mastery');
+const startStudyBtn = document.getElementById('start-study-btn');
+const backToHomeBtn = document.getElementById('back-to-home');
+const topicBackBtn = document.getElementById('topic-back-btn');
 
 // App state
 let allFlashcards = [];
@@ -530,10 +556,54 @@ function renderDeckCarousel() {
         card.appendChild(title);
         card.appendChild(badge);
         card.addEventListener('click', () => {
-            window.location.href = `flashcards.html?specialty=${s.slug}`;
+            renderTopicList(s.slug);
         });
         container.appendChild(card);
     });
+}
+
+let currentTopic = null;
+let topicViewScroll = 0;
+
+function renderTopicList(specialty) {
+    if (!topicView || !topicListEl) return;
+    topicListEl.innerHTML = '';
+    topicViewTitle.textContent = `Temas de ${specialtyNames[specialty] || specialty}`;
+    topics.filter(t => t.specialty === specialty).forEach(t => {
+        const card = document.createElement('div');
+        card.className = 'deck-card topic-card';
+        card.textContent = t.name;
+        card.addEventListener('click', () => openTopicDetail(t));
+        topicListEl.appendChild(card);
+    });
+    if (homeContainer) homeContainer.hidden = true;
+    if (topicDetail) topicDetail.hidden = true;
+    topicView.hidden = false;
+}
+
+function openTopicDetail(topic) {
+    currentTopic = topic;
+    if (topicView) {
+        topicViewScroll = topicView.scrollTop;
+        topicView.hidden = true;
+    }
+    if (!topicDetail) return;
+    topicDetail.hidden = false;
+    topicDetailTitle.textContent = `Tema: ${topic.name}`;
+    metricTotal.textContent = topic.total;
+    metricReviews.textContent = topic.reviews;
+    metricErrors.textContent = topic.errors;
+    metricMastery.textContent = `${topic.mastery}%`;
+    startStudyBtn.setAttribute('aria-label', `Comenzar a estudiar el tema ${topic.name}`);
+    startStudyBtn.textContent = 'Comenzar a estudiar';
+    startStudyBtn.onclick = () => {
+        alert(`Iniciando estudio de ${topic.name}`);
+        topic.reviews += 1;
+        metricReviews.textContent = topic.reviews;
+        saveTopics();
+        sessionStorage.setItem('topicId', topic.id);
+    };
+    setTimeout(() => topicDetailTitle.focus(), 0);
 }
 
 // Initialize flashcards page
@@ -602,6 +672,17 @@ function initHomePage() {
         userNameInput.addEventListener('change', handleNameChange);
     }
     if (themeToggle) themeToggle.addEventListener('click', toggleTheme);
+    if (backToHomeBtn) backToHomeBtn.addEventListener('click', () => {
+        if (topicView) topicView.hidden = true;
+        if (homeContainer) homeContainer.hidden = false;
+    });
+    if (topicBackBtn) topicBackBtn.addEventListener('click', () => {
+        if (topicDetail) topicDetail.hidden = true;
+        if (topicView) {
+            topicView.hidden = false;
+            topicView.scrollTop = topicViewScroll;
+        }
+    });
 }
 
 // Load flashcards from localStorage or use sample data

--- a/index.html
+++ b/index.html
@@ -53,6 +53,36 @@
             <div id="deck-carousel" class="deck-carousel"></div>
         </section>
     </div>
+
+    <section id="topic-view" hidden>
+        <button id="back-to-home" class="back-link">&larr; Volver</button>
+        <h2 id="topic-view-title"></h2>
+        <div id="topic-list" class="deck-carousel"></div>
+    </section>
+
+    <section id="topic-detail" hidden>
+        <button id="topic-back-btn" class="back-link">&larr; Volver</button>
+        <h2 id="topic-detail-title" tabindex="-1">Tema:</h2>
+        <div class="topic-metric-grid">
+            <div class="metric-card">
+                <span id="metric-total" class="metric-number" aria-live="polite"></span>
+                <span class="metric-label">total de flashcards</span>
+            </div>
+            <div class="metric-card">
+                <span id="metric-reviews" class="metric-number" aria-live="polite"></span>
+                <span class="metric-label">veces repasado</span>
+            </div>
+            <div class="metric-card">
+                <span id="metric-errors" class="metric-number" aria-live="polite"></span>
+                <span class="metric-label">errores totales</span>
+            </div>
+            <div class="metric-card">
+                <span id="metric-mastery" class="metric-number" aria-live="polite"></span>
+                <span class="metric-label">porcentaje de dominio</span>
+            </div>
+        </div>
+        <button id="start-study-btn" class="primary start-study-btn" aria-label="Comenzar a estudiar">Comenzar a estudiar</button>
+    </section>
     <script src="js/chart.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js" crossorigin="anonymous"></script>
     <script src="main.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -685,3 +685,44 @@ body.dark-mode .md-audio {
 .side-overlay.open {
     display: block;
 }
+
+/* Topic detail */
+.topic-metric-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 15px;
+    margin: 20px 0;
+}
+
+.metric-card {
+    background: var(--card-background);
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    padding: 20px;
+    text-align: center;
+}
+
+.metric-number {
+    font-size: 2rem;
+    display: block;
+    margin-bottom: 5px;
+}
+
+.metric-label {
+    text-transform: lowercase;
+    color: var(--secondary-color);
+}
+
+.start-study-btn {
+    display: block;
+    width: 100%;
+    max-width: 300px;
+    margin: 20px auto 0;
+    padding: 10px 20px;
+    border: none;
+    border-radius: var(--border-radius);
+    background: var(--primary-color);
+    color: #fff;
+    font-size: 1rem;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- show a list of topics and a new topic detail section
- style metric cards and start button
- allow navigating into a topic and start studying (placeholder)

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d331f5ffc8328b8e77805b82790f4