### PR TITLE
Fix theme toggle visibility over overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -85,6 +85,7 @@ h1 {
     box-shadow: -4px -4px 4px rgba(255, 255, 255, 0.6), 4px 4px 6px rgba(0, 0, 0, 0.15);
     transition: box-shadow 0.2s, transform 0.2s;
     position: absolute;
+    z-index: 1101;
     top: 20px;
     right: 20px;
 }


### PR DESCRIPTION
## Summary
- ensure `.theme-toggle` appears above the side overlay by adding a z-index

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d536852a4832899a3be367e412d5c