### PR TITLE
Replace emoji deck icons with CSS classes

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,12 +113,12 @@ let flashcards = [
 ];
 
 const specialties = [
-    { slug: 'medicina-interna', name: 'Medicina Interna', emoji: '🩺' },
-    { slug: 'pediatria', name: 'Pediatría', emoji: '👶' },
-    { slug: 'gineco-obstetricia', name: 'Ginecología y Obstetricia', emoji: '🤰' },
-    { slug: 'cirugia', name: 'Cirugía', emoji: '🔪' },
-    { slug: 'atls', name: 'ATLS', emoji: '🚑' },
-    { slug: 'acls', name: 'ACLS', emoji: '❤️' }
+    { slug: 'medicina-interna', name: 'Medicina Interna', icon: 'icon-stethoscope' },
+    { slug: 'pediatria', name: 'Pediatría', icon: 'icon-baby' },
+    { slug: 'gineco-obstetricia', name: 'Ginecología y Obstetricia', icon: 'icon-pregnancy' },
+    { slug: 'cirugia', name: 'Cirugía', icon: 'icon-scalpel' },
+    { slug: 'atls', name: 'ATLS', icon: 'icon-ambulance' },
+    { slug: 'acls', name: 'ACLS', icon: 'icon-heart' }
 ];
 
 const specialtyNames = specialties.reduce((acc, s) => {
@@ -608,9 +608,9 @@ function renderDeckCarousel() {
         const card = document.createElement('div');
         card.className = 'deck-card';
 
-        const icon = document.createElement('span');
-        icon.className = 'deck-icon';
-        icon.textContent = s.emoji;
+        const icon = document.createElement('i');
+        icon.className = `deck-icon ${s.icon}`;
+        icon.setAttribute('aria-hidden', 'true');
         if (stats[s.slug].pending > 0) {
             icon.classList.add('pending');
         }

--- a/styles.css
+++ b/styles.css
@@ -591,9 +591,20 @@ body.dark-mode .md-audio {
     margin-bottom: 5px;
 }
 
+.deck-icon::before {
+    display: block;
+}
+
 .deck-icon.pending {
     color: var(--danger-color);
 }
+
+.icon-stethoscope::before { content: '🩺'; }
+.icon-baby::before { content: '👶'; }
+.icon-pregnancy::before { content: '🤰'; }
+.icon-scalpel::before { content: '🔪'; }
+.icon-ambulance::before { content: '🚑'; }
+.icon-heart::before { content: '❤️'; }
 
 .deck-badge {
     position: absolute;


### PR DESCRIPTION
## Summary
- convert specialty emoji definitions to icon class names
- render deck carousel icons using `<i>` elements
- add CSS rules for new icon classes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687d5369c63883289a98d3973535f8e7