### PR TITLE
Improve responsive layout for button groups

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -192,6 +192,7 @@ body.dark-mode .theme-toggle:focus {
 .controls {
     display: flex;
     justify-content: center;
+    flex-wrap: wrap;
     gap: 15px;
     margin: 20px 0;
 }
@@ -219,6 +220,7 @@ body.dark-mode .theme-toggle:focus {
 .difficulty-buttons {
     display: flex;
     justify-content: center;
+    flex-wrap: wrap;
     gap: 10px;
     margin: 20px 0 40px;
 }
@@ -226,6 +228,7 @@ body.dark-mode .theme-toggle:focus {
 .manage-buttons {
     display: flex;
     justify-content: center;
+    flex-wrap: wrap;
     gap: 10px;
     margin-bottom: 20px;
 }
@@ -320,6 +323,12 @@ body.dark-mode .theme-toggle:focus {
     
     .controls {
         flex-wrap: wrap;
+    }
+
+    .difficulty-buttons,
+    .manage-buttons {
+        margin-bottom: 20px;
+        gap: 10px;
     }
     
     .flashcard-container {


### PR DESCRIPTION
## Summary
- allow `.difficulty-buttons`, `.manage-buttons`, and `.controls` to wrap their content
- give button groups margins when wrapping on narrow screens

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_687d536a2fc083288d8ebdfbf2462f7b