### PR TITLE
Remove duplicate theme listener

### DIFF
--- a/app.js
+++ b/app.js
@@ -716,7 +716,8 @@ function initFlashcardsPage() {
         importInput.addEventListener('change', importFlashcards);
     }
     if (prevBtn) prevBtn.addEventListener("click", showPreviousCard);
-    if (themeToggle) themeToggle.addEventListener('click', toggleTheme);
+    // The theme toggle listener is initialized in initHomePage
+    // if (themeToggle) themeToggle.addEventListener('click', toggleTheme);
     if (toggleGuideBtn) toggleGuideBtn.addEventListener('click', toggleGuide);
 
     // Difficulty buttons


### PR DESCRIPTION
## Summary
- comment out the redundant `themeToggle` handler in `initFlashcardsPage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ebc1d16f88328bf03003838689058