### PR TITLE
Show exam lobby on open

### DIFF
--- a/app.js
+++ b/app.js
@@ -347,6 +347,13 @@ function handleNameChange() {
     }
 }
 
+// Exam page handling
+function openExam() {
+    document.getElementById('exam-lobby').style.display = 'block';
+    document.getElementById('exam-question').style.display = 'none';
+    document.getElementById('exam-results').style.display = 'none';
+}
+
 // Progress chart and weak topics
 function renderProgressChart() {
     if (!progressChartCanvas || typeof Chart === 'undefined') return;


### PR DESCRIPTION
## Summary
- initialize exam view with lobby visible when `openExam()` runs

## Testing
- `git commit`

------
https://chatgpt.com/codex/tasks/task_e_687ebc1e34108328943dd3cbe6634ec4