### PR TITLE
Limit flashcard keyboard navigation to active page

### DIFF
--- a/app.js
+++ b/app.js
@@ -724,8 +724,6 @@ function initFlashcardsPage() {
         btn.addEventListener('click', () => setDifficulty(btn.dataset.difficulty));
     });
 
-    // Keyboard navigation
-    document.addEventListener('keydown', handleKeyDown);
 }
 
 function initHomePage() {
@@ -767,6 +765,16 @@ function initHomePage() {
             topicView.scrollTop = topicViewScroll;
         }
     });
+}
+
+// Show flashcards view and enable keyboard navigation
+function openFlashcards() {
+    document.addEventListener('keydown', handleKeyDown);
+}
+
+// Called when leaving flashcards view to disable keyboard navigation
+function hideAllPages() {
+    document.removeEventListener('keydown', handleKeyDown);
 }
 
 // Load flashcards from localStorage or use sample data
@@ -1074,7 +1082,9 @@ document.addEventListener('DOMContentLoaded', () => {
     loadFlashcards();
     if (document.querySelector('.home')) {
         initHomePage();
+        hideAllPages();
     } else {
         initFlashcardsPage();
+        openFlashcards();
     }
 });


### PR DESCRIPTION
## Summary
- move keyboard navigation setup out of `initFlashcardsPage`
- create `openFlashcards()` and `hideAllPages()` helpers
- call helpers when switching pages

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687ebc1f84c48328af292e70b5d84897