### PR TITLE
Add package.json with build and test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ ENARMAX es una pequeña aplicación web para repasar tarjetas médicas. Las tarj
 ## Uso
 
 1. Clona este repositorio.
-2. Abre el archivo `index.html` en tu navegador.
-3. Interactúa con las tarjetas usando los botones disponibles.
-4. Cambia entre modo día y noche con el botón "Modo Noche".
-5. Si deseas compilar los archivos TypeScript ejecuta `npm run build`. Esto creará la carpeta `dist/`, la cual no está versionada y puede eliminarse con `git clean -fd` u otra herramienta similar.
-6. Para practicar con límite de tiempo abre `exam.html` y comienza un examen adaptativo de 40 preguntas.
+2. Ejecuta `npm install` para instalar las dependencias de desarrollo.
+3. Abre el archivo `index.html` en tu navegador.
+4. Interactúa con las tarjetas usando los botones disponibles.
+5. Cambia entre modo día y noche con el botón "Modo Noche".
+6. Si deseas compilar los archivos TypeScript ejecuta `npm run build`. Esto creará la carpeta `dist/`, la cual no está versionada y puede eliminarse con `git clean -fd` u otra herramienta similar.
+7. Para ejecutar las pruebas corre `npm test`.
+8. Para practicar con límite de tiempo abre `exam.html` y comienza un examen adaptativo de 40 preguntas.
 
-No se requieren dependencias externas ni servidores adicionales; todo funciona de manera estática en el navegador.
+No se requieren servidores adicionales; todo funciona de manera estática en el navegador. El uso de `npm` es solo necesario para compilar o ejecutar las pruebas.
 
 ## Estructura del proyecto
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "enarmax",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.2",
+    "jest": "^29.6.4",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.2.2"
+  }
+}


### PR DESCRIPTION
## Summary
- set up a package.json for TypeScript and Jest
- document npm commands in the README

## Testing
- `npm run build` *(fails: No inputs were found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec525b26c8328ac0e243c9f8b056d