### PR TITLE
Implement larger carousel icons and topic previews

### DIFF
--- a/app.js
+++ b/app.js
@@ -662,7 +662,13 @@ function renderTopicList(specialty) {
     topics.filter(t => t.specialty === specialty).forEach(t => {
         const card = document.createElement('div');
         card.className = 'deck-card topic-card';
-        card.textContent = t.name;
+        const icon = document.createElement('i');
+        icon.className = 'topic-icon';
+        icon.textContent = '📚';
+        const title = document.createElement('span');
+        title.textContent = t.name;
+        card.appendChild(icon);
+        card.appendChild(title);
         card.addEventListener('click', () => openTopicDetail(t));
         topicListEl.appendChild(card);
     });

--- a/styles.css
+++ b/styles.css
@@ -581,10 +581,10 @@ body.dark-mode .md-audio {
 .deck-card {
     position: relative;
     flex: 0 0 auto;
-    min-width: 120px;
+    min-width: 150px;
     text-align: center;
     background: var(--card-background);
-    padding: 15px;
+    padding: 20px;
     border-radius: var(--border-radius);
     box-shadow: var(--box-shadow);
     cursor: pointer;
@@ -595,10 +595,14 @@ body.dark-mode .md-audio {
     transform: translateY(-4px);
 }
 
+.topic-card {
+    min-width: 150px;
+}
+
 .deck-icon {
-    font-size: 2rem;
+    font-size: 3rem;
     display: block;
-    margin-bottom: 5px;
+    margin-bottom: 10px;
 }
 
 .deck-icon::before {
@@ -625,6 +629,12 @@ body.dark-mode .md-audio {
     padding: 2px 6px;
     border-radius: 12px;
     font-size: 0.75rem;
+}
+
+.topic-card .topic-icon {
+    font-size: 2.5rem;
+    display: block;
+    margin-bottom: 10px;
 }
 
 


### PR DESCRIPTION
## Summary
- enlarge specialty cards and icons
- add carousel styling for topic cards
- show icons in topic list

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ef48f7bd88328a4ffbc87723ce884